### PR TITLE
Make allowed_commands wildcard fallback configurable and preserve explicit empties; add tests

### DIFF
--- a/src/modules/channel_policies.py
+++ b/src/modules/channel_policies.py
@@ -16,9 +16,9 @@ def default_channel_policy(can_speak=True):
     }
 
 
-def normalize_allowed_commands(commands):
+def normalize_allowed_commands(commands, fallback_to_wildcard=True):
     if commands is None:
-        return ["*"]
+        return ["*"] if fallback_to_wildcard else []
     if not isinstance(commands, (list, tuple, set)):
         commands = [commands]
 
@@ -32,7 +32,9 @@ def normalize_allowed_commands(commands):
         if command and command not in normalized:
             normalized.append(command)
 
-    return normalized or ["*"]
+    if normalized:
+        return normalized
+    return ["*"] if fallback_to_wildcard else []
 
 
 def normalize_channel_policy(policy):
@@ -40,9 +42,11 @@ def normalize_channel_policy(policy):
     if isinstance(policy, dict):
         base["can_speak"] = bool(policy.get("can_speak", base["can_speak"]))
         base["respond_all"] = bool(policy.get("respond_all", base["respond_all"]))
-        base["allowed_commands"] = normalize_allowed_commands(
-            policy.get("allowed_commands", base["allowed_commands"])
-        )
+        if "allowed_commands" in policy:
+            base["allowed_commands"] = normalize_allowed_commands(
+                policy.get("allowed_commands"),
+                fallback_to_wildcard=False,
+            )
     return base
 
 

--- a/tests/test_channel_policies.py
+++ b/tests/test_channel_policies.py
@@ -1,0 +1,56 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+def load_channel_policies_module():
+    module_path = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "src"
+        / "modules"
+        / "channel_policies.py"
+    )
+    spec = importlib.util.spec_from_file_location("channel_policies", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load channel_policies module spec")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+channel_policies = load_channel_policies_module()
+normalize_channel_policy = channel_policies.normalize_channel_policy
+normalize_allowed_commands = channel_policies.normalize_allowed_commands
+
+
+class ChannelPolicyNormalizationTests(unittest.TestCase):
+    def test_default_policy_keeps_wildcard(self):
+        policy = normalize_channel_policy({"can_speak": True})
+        self.assertEqual(policy["allowed_commands"], ["*"])
+
+    def test_explicit_empty_allowed_commands_is_preserved(self):
+        policy = normalize_channel_policy(
+            {"can_speak": False, "allowed_commands": []}
+        )
+        self.assertEqual(policy["allowed_commands"], [])
+
+    def test_explicit_none_allowed_commands_is_preserved_as_empty(self):
+        policy = normalize_channel_policy(
+            {"can_speak": False, "allowed_commands": None}
+        )
+        self.assertEqual(policy["allowed_commands"], [])
+
+    def test_explicit_commands_are_normalized(self):
+        policy = normalize_channel_policy(
+            {"allowed_commands": ["$Ping", " ping ", "", None]}
+        )
+        self.assertEqual(policy["allowed_commands"], ["ping"])
+
+    def test_normalize_allowed_commands_respects_fallback_flag(self):
+        self.assertEqual(normalize_allowed_commands([], fallback_to_wildcard=True), ["*"])
+        self.assertEqual(normalize_allowed_commands([], fallback_to_wildcard=False), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent implicit wildcarding when a policy explicitly sets `allowed_commands` to an empty list or `None`, so an administrator can disable all commands for a channel.
- Provide callers control over whether normalization should fall back to a wildcard to avoid surprising default behavior in some normalization paths.

### Description
- Add `fallback_to_wildcard` parameter to `normalize_allowed_commands` with the default behavior preserved as `True`.
- Change `normalize_allowed_commands` to return an empty list when normalization yields no commands and `fallback_to_wildcard` is `False`.
- Update `normalize_channel_policy` to only normalize `allowed_commands` when it is present in the input and call the normalizer with `fallback_to_wildcard=False` to preserve explicit emptiness.
- Add `tests/test_channel_policies.py` with unit tests verifying wildcard fallback behavior, explicit empty/None preservation, and command normalization.

### Testing
- Ran the new unit tests with `python -m unittest tests.test_channel_policies.py`.
- All 5 tests in `tests/test_channel_policies.py` passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad95b0b8e4832cab7a1ae87101c275)