### PR TITLE
SONA-38: Add user policy layer with group-aware evaluation

### DIFF
--- a/src/modules/channel_policies.py
+++ b/src/modules/channel_policies.py
@@ -182,6 +182,7 @@ class ChannelPolicies:
         self.sonata = sonata
         self.users = {}
         self.channels = {}
+        self.groups = {}
         self.loaded = False
         self.policy_api = get_or_create_policy_api(sonata)
         self._ensure_chat_namespace()
@@ -248,6 +249,8 @@ class ChannelPolicies:
             self._sync_user_scope(user_id, policy)
         for channel_id, policy in self.channels.items():
             self._sync_channel_scope(channel_id, policy)
+        for group_id, data in self.groups.items():
+            self._sync_group(group_id, data)
 
     def _normalize_users_map(self, users):
         if not isinstance(users, dict):
@@ -273,25 +276,104 @@ class ChannelPolicies:
     def _serialize_users(self):
         return {user_id: policy.to_dict() for user_id, policy in self.users.items()}
 
+    def _normalize_groups_map(self, groups):
+        if not isinstance(groups, dict):
+            return {}
+
+        normalized = {}
+        for group_id, data in groups.items():
+            group_key = str(group_id or "").strip().lower()
+            if not group_key:
+                continue
+            if not isinstance(data, dict):
+                data = {}
+            rules = []
+            for rule in data.get("rules", []):
+                if not isinstance(rule, dict):
+                    continue
+                action = str(rule.get("action") or "").strip().lower()
+                effect = str(rule.get("effect") or "").strip().lower()
+                if not action or effect not in {EFFECT_ALLOW, EFFECT_DENY}:
+                    continue
+                rules.append({"action": action, "effect": effect})
+            normalized[group_key] = {
+                "members": sorted(
+                    {str(member).strip() for member in data.get("members", []) if str(member).strip()}
+                ),
+                "roles": sorted(
+                    {str(role_id).strip() for role_id in data.get("roles", []) if str(role_id).strip()}
+                ),
+                "rules": rules,
+            }
+        return normalized
+
+    def _serialize_groups(self):
+        serialized = {}
+        for group_id in self.policy_api.list_groups("chat"):
+            group_name = self._group_name_from_id(group_id)
+            group_data = self.policy_api.get_group("chat", group_name) or {}
+            group_rules = self.policy_api.get_scope_rules("chat", "group", group_id)
+            serialized[group_id] = {
+                "members": group_data.get("members", []),
+                "roles": group_data.get("roles", []),
+                "rules": [
+                    {"action": rule.action, "effect": rule.effect}
+                    for rule in group_rules
+                ],
+            }
+        return serialized
+
+    def _group_name_from_id(self, group_id):
+        group_key = str(group_id or "").strip().lower()
+        if ":" in group_key:
+            return group_key.split(":", 1)[1]
+        return group_key
+
+    def _sync_group(self, group_id, data):
+        group_name = self._group_name_from_id(group_id)
+        self.policy_api.upsert_group(
+            "chat",
+            group_name,
+            members=data.get("members", []),
+            role_ids=data.get("roles", []),
+        )
+        self.policy_api.clear_scope("chat", "group", group_id)
+        for rule in data.get("rules", []):
+            self.policy_api.set_group_rule(
+                "chat",
+                group_name,
+                rule["action"],
+                rule["effect"],
+            )
+
     def _persist(self):
         serialized_channels = self._serialize_channels()
         serialized_users = self._serialize_users()
-        self.sonata.config.set(channels=serialized_channels, users=serialized_users)
+        serialized_groups = self._serialize_groups()
+        self.sonata.config.set(
+            channels=serialized_channels,
+            users=serialized_users,
+            groups=serialized_groups,
+        )
         if hasattr(self.sonata, "beacon"):
             policies_branch = self.sonata.beacon.branch("policies")
             policies_branch.illuminate("channels", serialized_channels)
             policies_branch.illuminate("users", serialized_users)
+            policies_branch.illuminate("groups", serialized_groups)
 
     def init(self):
         beacon_channels = {}
         beacon_users = {}
+        beacon_groups = {}
         if hasattr(self.sonata, "beacon"):
             policies_branch = self.sonata.beacon.branch("policies")
             beacon_channels = policies_branch.discover("channels") or {}
             beacon_users = policies_branch.discover("users") or {}
+            beacon_groups = policies_branch.discover("groups") or {}
 
         configured_channels = self.sonata.config.get("channels", {})
         configured_users = self.sonata.config.get("users", {})
+        configured_groups = self.sonata.config.get("groups", {})
 
         users = {}
         users.update(self._normalize_users_map(beacon_users))
@@ -301,8 +383,13 @@ class ChannelPolicies:
         channels.update(self._normalize_channels_map(beacon_channels))
         channels.update(self._normalize_channels_map(configured_channels))
 
+        groups = {}
+        groups.update(self._normalize_groups_map(beacon_groups))
+        groups.update(self._normalize_groups_map(configured_groups))
+
         self.users = users
         self.channels = channels
+        self.groups = groups
         self.loaded = True
         self._sync_policy_api()
         self._persist()
@@ -364,47 +451,65 @@ class ChannelPolicies:
         return policy.clone()
 
     def upsert_user_group(self, name, *, members=None, role_ids=None):
-        return self.policy_api.upsert_group(
+        group_id = self.policy_api.upsert_group(
             "chat",
             name,
             members=members,
             role_ids=role_ids,
         )
+        self.loaded = True
+        self._persist()
+        return group_id
 
     def remove_user_group(self, name):
-        return self.policy_api.remove_group("chat", name)
+        removed = self.policy_api.remove_group("chat", name)
+        self.loaded = True
+        self._persist()
+        return removed
 
     def allow_group_command(self, group_name, command):
         command_name = normalize_command_name(command)
         if not command_name:
             return None
-        return self.policy_api.set_group_rule(
+        rule = self.policy_api.set_group_rule(
             "chat", group_name, f"chat.command.{command_name}", EFFECT_ALLOW
         )
+        self.loaded = True
+        self._persist()
+        return rule
 
     def deny_group_command(self, group_name, command):
         command_name = normalize_command_name(command)
         if not command_name:
             return None
-        return self.policy_api.set_group_rule(
+        rule = self.policy_api.set_group_rule(
             "chat", group_name, f"chat.command.{command_name}", EFFECT_DENY
         )
+        self.loaded = True
+        self._persist()
+        return rule
 
     def allow_group_feature(self, group_name, action):
         action_name = str(action or "").strip().lower()
         if not action_name:
             return None
-        return self.policy_api.set_group_rule(
+        rule = self.policy_api.set_group_rule(
             "chat", group_name, action_name, EFFECT_ALLOW
         )
+        self.loaded = True
+        self._persist()
+        return rule
 
     def deny_group_feature(self, group_name, action):
         action_name = str(action or "").strip().lower()
         if not action_name:
             return None
-        return self.policy_api.set_group_rule(
+        rule = self.policy_api.set_group_rule(
             "chat", group_name, action_name, EFFECT_DENY
         )
+        self.loaded = True
+        self._persist()
+        return rule
 
     def get_channels(self):
         if not self.loaded:

--- a/src/modules/channel_policies.py
+++ b/src/modules/channel_policies.py
@@ -180,6 +180,7 @@ class ChannelPolicy:
 class ChannelPolicies:
     def __init__(self, sonata):
         self.sonata = sonata
+        self.users = {}
         self.channels = {}
         self.loaded = False
         self.policy_api = get_or_create_policy_api(sonata)
@@ -200,44 +201,61 @@ class ChannelPolicies:
 
     def _sync_channel_scope(self, channel_id, policy):
         key = str(channel_id)
+        self._sync_scope("channel", key, policy)
+
+    def _sync_user_scope(self, user_id, policy):
+        key = str(user_id)
+        self._sync_scope("user", key, policy)
+
+    def _sync_scope(self, scope, scope_id, policy):
         policy = ChannelPolicy.normalize(policy)
-        self.policy_api.clear_scope("chat", "channel", key)
+        self.policy_api.clear_scope("chat", scope, scope_id)
 
         if not policy.can_speak:
             self.policy_api.set_rule(
-                "chat", "channel", key, "chat.can_speak", EFFECT_DENY
+                "chat", scope, scope_id, "chat.can_speak", EFFECT_DENY
             )
 
         if policy.respond_all:
             self.policy_api.set_rule(
-                "chat", "channel", key, "chat.respond_all", EFFECT_ALLOW
+                "chat", scope, scope_id, "chat.respond_all", EFFECT_ALLOW
             )
 
         if policy.command_policy_mode == DENYLIST:
             for command in policy.commands:
                 self.policy_api.set_rule(
                     "chat",
-                    "channel",
-                    key,
+                    scope,
+                    scope_id,
                     f"chat.command.{normalize_command_name(command)}",
                     EFFECT_DENY,
                 )
         else:
             self.policy_api.set_rule(
-                "chat", "channel", key, "chat.command.*", EFFECT_DENY
+                "chat", scope, scope_id, "chat.command.*", EFFECT_DENY
             )
             for command in policy.commands:
                 self.policy_api.set_rule(
                     "chat",
-                    "channel",
-                    key,
+                    scope,
+                    scope_id,
                     f"chat.command.{normalize_command_name(command)}",
                     EFFECT_ALLOW,
                 )
 
     def _sync_policy_api(self):
+        for user_id, policy in self.users.items():
+            self._sync_user_scope(user_id, policy)
         for channel_id, policy in self.channels.items():
             self._sync_channel_scope(channel_id, policy)
+
+    def _normalize_users_map(self, users):
+        if not isinstance(users, dict):
+            return {}
+        return {
+            str(user_id): ChannelPolicy.normalize(policy)
+            for user_id, policy in users.items()
+        }
 
     def _normalize_channels_map(self, channels):
         if not isinstance(channels, dict):
@@ -252,27 +270,141 @@ class ChannelPolicies:
             channel_id: policy.to_dict() for channel_id, policy in self.channels.items()
         }
 
+    def _serialize_users(self):
+        return {user_id: policy.to_dict() for user_id, policy in self.users.items()}
+
     def _persist(self):
-        serialized = self._serialize_channels()
-        self.sonata.config.set(channels=serialized)
+        serialized_channels = self._serialize_channels()
+        serialized_users = self._serialize_users()
+        self.sonata.config.set(channels=serialized_channels, users=serialized_users)
         if hasattr(self.sonata, "beacon"):
-            self.sonata.beacon.branch("policies").illuminate("channels", serialized)
+            policies_branch = self.sonata.beacon.branch("policies")
+            policies_branch.illuminate("channels", serialized_channels)
+            policies_branch.illuminate("users", serialized_users)
 
     def init(self):
         beacon_channels = {}
+        beacon_users = {}
         if hasattr(self.sonata, "beacon"):
-            beacon_channels = (
-                self.sonata.beacon.branch("policies").discover("channels") or {}
-            )
+            policies_branch = self.sonata.beacon.branch("policies")
+            beacon_channels = policies_branch.discover("channels") or {}
+            beacon_users = policies_branch.discover("users") or {}
+
         configured_channels = self.sonata.config.get("channels", {})
+        configured_users = self.sonata.config.get("users", {})
+
+        users = {}
+        users.update(self._normalize_users_map(beacon_users))
+        users.update(self._normalize_users_map(configured_users))
+
         channels = {}
         channels.update(self._normalize_channels_map(beacon_channels))
         channels.update(self._normalize_channels_map(configured_channels))
+
+        self.users = users
         self.channels = channels
         self.loaded = True
         self._sync_policy_api()
         self._persist()
         return self.channels
+
+    def get_users(self):
+        if not self.loaded:
+            self.init()
+        return {user_id: policy.clone() for user_id, policy in self.users.items()}
+
+    def get_user_policy(self, user_id):
+        if not self.loaded:
+            self.init()
+        policy = self.users.get(str(user_id))
+        if policy is None:
+            return ChannelPolicy.default()
+        return policy.clone()
+
+    def set_user_policy(self, user_id, **updates):
+        key = str(user_id)
+        current = self.get_user_policy(key)
+        policy = current.with_updates(**updates)
+        self.users[key] = policy
+        self._sync_user_scope(key, policy)
+        self.loaded = True
+        self._persist()
+        return policy.clone()
+
+    def remove_user_policy(self, user_id):
+        if not self.loaded:
+            self.init()
+        key = str(user_id)
+        removed = self.users.pop(key, None)
+        self.policy_api.clear_scope("chat", "user", key)
+        self._persist()
+        return removed.clone() if removed is not None else None
+
+    def set_user_flag(self, user_id, key, value):
+        if key not in {"can_speak", "respond_all"}:
+            raise ValueError("User flag must be can_speak or respond_all")
+        return self.set_user_policy(user_id, **{key: bool(value)})
+
+    def allow_user_command(self, user_id, command):
+        key = str(user_id)
+        policy = self.get_user_policy(key).allow_command(command)
+        self.users[key] = policy
+        self._sync_user_scope(key, policy)
+        self.loaded = True
+        self._persist()
+        return policy.clone()
+
+    def deny_user_command(self, user_id, command):
+        key = str(user_id)
+        policy = self.get_user_policy(key).deny_command(command)
+        self.users[key] = policy
+        self._sync_user_scope(key, policy)
+        self.loaded = True
+        self._persist()
+        return policy.clone()
+
+    def upsert_user_group(self, name, *, members=None, role_ids=None):
+        return self.policy_api.upsert_group(
+            "chat",
+            name,
+            members=members,
+            role_ids=role_ids,
+        )
+
+    def remove_user_group(self, name):
+        return self.policy_api.remove_group("chat", name)
+
+    def allow_group_command(self, group_name, command):
+        command_name = normalize_command_name(command)
+        if not command_name:
+            return None
+        return self.policy_api.set_group_rule(
+            "chat", group_name, f"chat.command.{command_name}", EFFECT_ALLOW
+        )
+
+    def deny_group_command(self, group_name, command):
+        command_name = normalize_command_name(command)
+        if not command_name:
+            return None
+        return self.policy_api.set_group_rule(
+            "chat", group_name, f"chat.command.{command_name}", EFFECT_DENY
+        )
+
+    def allow_group_feature(self, group_name, action):
+        action_name = str(action or "").strip().lower()
+        if not action_name:
+            return None
+        return self.policy_api.set_group_rule(
+            "chat", group_name, action_name, EFFECT_ALLOW
+        )
+
+    def deny_group_feature(self, group_name, action):
+        action_name = str(action or "").strip().lower()
+        if not action_name:
+            return None
+        return self.policy_api.set_group_rule(
+            "chat", group_name, action_name, EFFECT_DENY
+        )
 
     def get_channels(self):
         if not self.loaded:
@@ -349,27 +481,48 @@ class ChannelPolicies:
         self._persist()
         return policy.clone()
 
-    def can_speak(self, guild_id, channel_id, user_id=None):
+    def can_speak(
+        self, guild_id, channel_id, user_id=None, role_ids=None, group_ids=None
+    ):
         return self.policy_api.evaluate(
             "chat",
             "chat.can_speak",
             guild_id=guild_id,
             channel_id=channel_id,
             user_id=user_id,
+            role_ids=role_ids,
+            group_ids=group_ids,
             default=True,
         )
 
-    def should_respond_all(self, guild_id, channel_id, user_id=None):
+    def should_respond_all(
+        self,
+        guild_id,
+        channel_id,
+        user_id=None,
+        role_ids=None,
+        group_ids=None,
+    ):
         return self.policy_api.evaluate(
             "chat",
             "chat.respond_all",
             guild_id=guild_id,
             channel_id=channel_id,
             user_id=user_id,
+            role_ids=role_ids,
+            group_ids=group_ids,
             default=False,
         )
 
-    def is_command_allowed(self, guild_id, channel_id, command, user_id=None):
+    def is_command_allowed(
+        self,
+        guild_id,
+        channel_id,
+        command,
+        user_id=None,
+        role_ids=None,
+        group_ids=None,
+    ):
         command_name = normalize_command_name(command)
         if not command_name:
             return True
@@ -379,6 +532,8 @@ class ChannelPolicies:
             guild_id=guild_id,
             channel_id=channel_id,
             user_id=user_id,
+            role_ids=role_ids,
+            group_ids=group_ids,
             default=True,
         )
 

--- a/src/modules/plugins/chat.py
+++ b/src/modules/plugins/chat.py
@@ -234,10 +234,12 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
     policy_manager = Sonata.chat.policy_manager
     command_name = get_command_name(message.content)
     is_command = bool(command_name)
+    role_ids = [str(role.id) for role in getattr(message.author, "roles", [])]
     can_speak = policy_manager.can_speak(
         guild_id=message.guild.id,
         channel_id=message.channel.id,
         user_id=message.author.id,
+        role_ids=role_ids,
     )
     if not can_speak:
         if is_command:
@@ -253,6 +255,7 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
         channel_id=message.channel.id,
         user_id=message.author.id,
         command=command_name,
+        role_ids=role_ids,
     ):
         await message.reply(
             f"`{command_name}` is not allowed in this channel.",
@@ -268,6 +271,7 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
         guild_id=message.guild.id,
         channel_id=message.channel.id,
         user_id=message.author.id,
+        role_ids=role_ids,
     )
 
     _guild_name = message.guild.name

--- a/src/modules/policy_api.py
+++ b/src/modules/policy_api.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-SCOPES = ("guild", "channel", "user")
-EVAL_PRECEDENCE = ("user", "channel", "guild")
+SCOPES = ("guild", "channel", "group", "user")
+EVAL_PRECEDENCE = ("user", "group", "channel", "guild")
 EFFECT_ALLOW = "allow"
 EFFECT_DENY = "deny"
 
@@ -29,6 +29,9 @@ class PolicyAPI:
     def __init__(self):
         self._namespaces: dict[str, PolicyNamespace] = {}
         self._rules: dict[str, dict[str, dict[str, list[PolicyRule]]]] = {}
+        self._groups: dict[str, dict[str, set[str]]] = {}
+        self._group_roles: dict[str, dict[str, set[str]]] = {}
+        self._role_resolver = None
         self.register_namespace("core", plugin=False)
 
     def register_namespace(
@@ -50,6 +53,8 @@ class PolicyAPI:
         )
         self._namespaces[key] = ns
         self._rules[key] = {scope: {} for scope in SCOPES}
+        self._groups[key] = {}
+        self._group_roles[key] = {}
         return ns
 
     def has_namespace(self, namespace: str) -> bool:
@@ -69,6 +74,149 @@ class PolicyAPI:
         key = self._normalize_namespace(namespace)
         ns = self._require_namespace(key)
         ns.active = True
+
+    def set_role_resolver(self, resolver):
+        self._role_resolver = resolver
+
+    def normalize_group_id(self, namespace: str, group_name: str) -> str:
+        ns = self._normalize_namespace(namespace)
+        name = str(group_name or "").strip().lower()
+        if not name:
+            raise ValueError("Group name is required")
+        return f"{ns}:{name}"
+
+    def upsert_group(
+        self,
+        namespace: str,
+        group_name: str,
+        *,
+        members=None,
+        role_ids=None,
+    ) -> str:
+        key = self._normalize_namespace(namespace)
+        self._require_namespace(key)
+        group_id = self.normalize_group_id(key, group_name)
+
+        entry = self._groups[key].setdefault(group_id, set())
+        if members is not None:
+            entry.clear()
+            entry.update(self._normalize_identifier_set(members))
+
+        roles = self._group_roles[key].setdefault(group_id, set())
+        if role_ids is not None:
+            roles.clear()
+            roles.update(self._normalize_identifier_set(role_ids))
+
+        return group_id
+
+    def remove_group(self, namespace: str, group_name: str) -> bool:
+        key = self._normalize_namespace(namespace)
+        self._require_namespace(key)
+        group_id = self.normalize_group_id(key, group_name)
+        removed = False
+
+        if group_id in self._groups[key]:
+            self._groups[key].pop(group_id, None)
+            removed = True
+        if group_id in self._group_roles[key]:
+            self._group_roles[key].pop(group_id, None)
+            removed = True
+
+        self._rules[key]["group"].pop(group_id, None)
+        return removed
+
+    def add_group_member(self, namespace: str, group_name: str, user_id) -> str:
+        key = self._normalize_namespace(namespace)
+        group_id = self.upsert_group(key, group_name)
+        self._groups[key][group_id].add(self._normalize_scope_id(user_id))
+        return group_id
+
+    def remove_group_member(self, namespace: str, group_name: str, user_id) -> bool:
+        key = self._normalize_namespace(namespace)
+        group_id = self.normalize_group_id(key, group_name)
+        members = self._groups.get(key, {}).get(group_id)
+        if not members:
+            return False
+        user_key = self._normalize_scope_id(user_id)
+        if user_key not in members:
+            return False
+        members.remove(user_key)
+        return True
+
+    def bind_group_role(self, namespace: str, group_name: str, role_id) -> str:
+        key = self._normalize_namespace(namespace)
+        group_id = self.upsert_group(key, group_name)
+        self._group_roles[key][group_id].add(self._normalize_scope_id(role_id))
+        return group_id
+
+    def unbind_group_role(self, namespace: str, group_name: str, role_id) -> bool:
+        key = self._normalize_namespace(namespace)
+        group_id = self.normalize_group_id(key, group_name)
+        roles = self._group_roles.get(key, {}).get(group_id)
+        if not roles:
+            return False
+        role_key = self._normalize_scope_id(role_id)
+        if role_key not in roles:
+            return False
+        roles.remove(role_key)
+        return True
+
+    def list_groups(self, namespace: str) -> list[str]:
+        key = self._normalize_namespace(namespace)
+        self._require_namespace(key)
+        return sorted(self._groups[key].keys())
+
+    def get_group(self, namespace: str, group_name: str) -> dict[str, list[str]] | None:
+        key = self._normalize_namespace(namespace)
+        self._require_namespace(key)
+        group_id = self.normalize_group_id(key, group_name)
+        members = self._groups[key].get(group_id)
+        roles = self._group_roles[key].get(group_id)
+        if members is None and roles is None:
+            return None
+        return {
+            "id": group_id,
+            "members": sorted(members or []),
+            "roles": sorted(roles or []),
+        }
+
+    def set_group_rule(
+        self,
+        namespace: str,
+        group_name: str,
+        action: str,
+        effect: str,
+    ) -> PolicyRule:
+        key = self._normalize_namespace(namespace)
+        group_id = self.normalize_group_id(key, group_name)
+        self.upsert_group(key, group_name)
+        return self.set_rule(key, "group", group_id, action, effect)
+
+    def resolve_groups(
+        self,
+        namespace: str,
+        *,
+        user_id=None,
+        role_ids=None,
+    ) -> list[str]:
+        key = self._normalize_namespace(namespace)
+        self._require_namespace(key)
+
+        normalized_user = self._optional_scope_id(user_id)
+        resolved = set()
+
+        if normalized_user is not None:
+            for group_id, members in self._groups[key].items():
+                if normalized_user in members:
+                    resolved.add(group_id)
+
+        roles = self._resolve_runtime_roles(key, normalized_user, role_ids)
+        if roles:
+            for group_id, mapped_roles in self._group_roles[key].items():
+                if mapped_roles.intersection(roles):
+                    resolved.add(group_id)
+
+        return sorted(resolved)
 
     def set_rule(
         self,
@@ -137,6 +285,8 @@ class PolicyAPI:
         guild_id=None,
         channel_id=None,
         user_id=None,
+        group_ids=None,
+        role_ids=None,
         default: bool | None = None,
     ) -> bool:
         key = self._normalize_namespace(namespace)
@@ -150,15 +300,24 @@ class PolicyAPI:
             "guild": self._optional_scope_id(guild_id),
             "channel": self._optional_scope_id(channel_id),
             "user": self._optional_scope_id(user_id),
+            "group": self._resolve_group_scope_ids(
+                key,
+                group_ids=group_ids,
+                user_id=user_id,
+                role_ids=role_ids,
+            ),
         }
 
         seen_allow = False
         for scope in EVAL_PRECEDENCE:
-            scope_id_key = scope_ids[scope]
-            if scope_id_key is None:
+            ids = scope_ids[scope]
+            if ids is None:
                 continue
 
-            decision = self._evaluate_scope(key, scope, scope_id_key, action_key)
+            if isinstance(ids, str):
+                ids = [ids]
+
+            decision = self._evaluate_scope_ids(key, scope, ids, action_key)
             if decision == EFFECT_DENY:
                 return False
             if decision == EFFECT_ALLOW:
@@ -168,6 +327,27 @@ class PolicyAPI:
             return True
 
         return self._resolve_default(ns, action_key, default)
+
+    def _evaluate_scope_ids(
+        self,
+        namespace: str,
+        scope: str,
+        scope_ids: list[str],
+        action: str,
+    ) -> str | None:
+        saw_allow = False
+        for scope_id_key in scope_ids:
+            if scope_id_key is None:
+                continue
+
+            decision = self._evaluate_scope(namespace, scope, scope_id_key, action)
+            if decision == EFFECT_DENY:
+                return EFFECT_DENY
+            if decision == EFFECT_ALLOW:
+                saw_allow = True
+        if saw_allow:
+            return EFFECT_ALLOW
+        return None
 
     def _evaluate_scope(
         self,
@@ -251,6 +431,61 @@ class PolicyAPI:
             return None
         key = str(scope_id).strip()
         return key or None
+
+    def _normalize_identifier_set(self, values) -> set[str]:
+        if values is None:
+            return set()
+        if not isinstance(values, (list, tuple, set)):
+            values = [values]
+        normalized = set()
+        for value in values:
+            key = self._optional_scope_id(value)
+            if key is not None:
+                normalized.add(key)
+        return normalized
+
+    def _resolve_runtime_roles(
+        self, namespace: str, user_id: str | None, role_ids
+    ) -> set[str]:
+        role_set = self._normalize_identifier_set(role_ids)
+        if role_set:
+            return role_set
+
+        if self._role_resolver is None:
+            return set()
+        if user_id is None:
+            return set()
+
+        try:
+            resolved = self._role_resolver(namespace, user_id)
+        except Exception:
+            return set()
+        return self._normalize_identifier_set(resolved)
+
+    def _resolve_group_scope_ids(
+        self,
+        namespace: str,
+        *,
+        group_ids,
+        user_id,
+        role_ids,
+    ) -> list[str]:
+        if group_ids is not None:
+            if not isinstance(group_ids, (list, tuple, set)):
+                group_ids = [group_ids]
+            normalized = set()
+            for group_id in group_ids:
+                if group_id is None:
+                    continue
+                group_key = str(group_id).strip().lower()
+                if not group_key:
+                    continue
+                if not group_key.startswith(f"{namespace}:"):
+                    group_key = self.normalize_group_id(namespace, group_key)
+                normalized.add(group_key)
+            return sorted(normalized)
+
+        return self.resolve_groups(namespace, user_id=user_id, role_ids=role_ids)
 
     def _normalize_action(self, action: str) -> str:
         key = str(action or "").strip().lower()

--- a/tests/test_policy_api.py
+++ b/tests/test_policy_api.py
@@ -190,6 +190,75 @@ class PolicyApiTests(unittest.TestCase):
             groups = api.resolve_groups("chat", user_id=7, role_ids=["role3"])
             self.assertEqual(groups, ["chat:g1", "chat:g2", "chat:g3"])
 
+    def test_direct_user_allow_deny(self):
+        policies = ChannelPolicies(FakeSonata())
+        policies.set_user_flag(5, "can_speak", False)
+        self.assertFalse(policies.can_speak(guild_id=1, channel_id=10, user_id=5))
+
+        policies.set_user_flag(5, "can_speak", True)
+        self.assertTrue(policies.can_speak(guild_id=1, channel_id=10, user_id=5))
+
+    def test_group_targeted_user_effects_apply(self):
+        policies = ChannelPolicies(FakeSonata())
+        policies.upsert_user_group("mods", members=["7"])
+        policies.deny_group_command("mods", "ban")
+
+        self.assertFalse(
+            policies.is_command_allowed(
+                guild_id=1,
+                channel_id=10,
+                user_id=7,
+                command="ban",
+            )
+        )
+        self.assertTrue(
+            policies.is_command_allowed(
+                guild_id=1,
+                channel_id=10,
+                user_id=8,
+                command="ban",
+            )
+        )
+
+    def test_user_rule_interacts_with_group_and_deny_wins(self):
+        policies = ChannelPolicies(FakeSonata())
+        policies.upsert_user_group("mods", members=["7"])
+        policies.deny_group_command("mods", "ban")
+        policies.allow_user_command(7, "ban")
+
+        self.assertFalse(
+            policies.is_command_allowed(
+                guild_id=1,
+                channel_id=10,
+                user_id=7,
+                command="ban",
+            )
+        )
+
+    def test_precedence_user_channel_guild_and_namespace_isolation(self):
+        api = PolicyAPI()
+        api.register_namespace("chat", plugin=True)
+        api.register_namespace("beacon", plugin=True)
+
+        api.set_rule("chat", "guild", 1, "chat.command.ping", "allow")
+        api.set_rule("chat", "channel", 2, "chat.command.ping", "allow")
+        api.set_rule("chat", "user", 3, "chat.command.ping", "deny")
+
+        self.assertFalse(
+            api.evaluate(
+                "chat", "chat.command.ping", guild_id=1, channel_id=2, user_id=3
+            )
+        )
+        self.assertFalse(
+            api.evaluate(
+                "beacon",
+                "chat.command.ping",
+                guild_id=1,
+                channel_id=2,
+                user_id=3,
+            )
+        )
+
     def test_channel_policy_behavior_migrates_via_policy_api(self):
         sonata = FakeSonata()
         policies = ChannelPolicies(sonata)

--- a/tests/test_policy_api.py
+++ b/tests/test_policy_api.py
@@ -113,6 +113,83 @@ class PolicyApiTests(unittest.TestCase):
         api.unload_namespace("chat")
         self.assertTrue(api.evaluate("chat", "chat.command.help", channel_id=11))
 
+    def test_manual_group_resolution_and_group_rule_eval(self):
+        api = PolicyAPI()
+        api.register_namespace("chat", plugin=True)
+        api.upsert_group("chat", "mods", members=["7"])
+        api.set_group_rule("chat", "mods", "chat.command.ban", "allow")
+
+        groups = api.resolve_groups("chat", user_id=7)
+        self.assertEqual(groups, ["chat:mods"])
+        self.assertTrue(
+            api.evaluate(
+                "chat",
+                "chat.command.ban",
+                user_id=7,
+            )
+        )
+
+    def test_role_derived_group_resolution(self):
+        api = PolicyAPI()
+        api.register_namespace("chat", plugin=True)
+        api.bind_group_role("chat", "admins", "role-admin")
+        api.set_group_rule("chat", "admins", "chat.command.shutdown", "allow")
+
+        groups = api.resolve_groups("chat", user_id=9, role_ids=["role-admin"])
+        self.assertEqual(groups, ["chat:admins"])
+        self.assertTrue(
+            api.evaluate(
+                "chat",
+                "chat.command.shutdown",
+                user_id=9,
+                role_ids=["role-admin"],
+            )
+        )
+
+    def test_mixed_group_membership_is_deterministic_with_deny_wins(self):
+        api = PolicyAPI()
+        api.register_namespace("chat", plugin=True)
+        api.upsert_group("chat", "mods", members=["7"])
+        api.upsert_group("chat", "muted", members=["7"])
+        api.set_group_rule("chat", "mods", "chat.command.kick", "allow")
+        api.set_group_rule("chat", "muted", "chat.command.kick", "deny")
+
+        self.assertFalse(api.evaluate("chat", "chat.command.kick", user_id=7))
+
+    def test_group_lookup_is_namespace_safe(self):
+        api = PolicyAPI()
+        api.register_namespace("chat", plugin=True)
+        api.register_namespace("beacon", plugin=True)
+        api.upsert_group("chat", "staff", members=["1"])
+        api.upsert_group("beacon", "staff", members=["2"])
+
+        self.assertEqual(api.resolve_groups("chat", user_id=1), ["chat:staff"])
+        self.assertEqual(api.resolve_groups("beacon", user_id=2), ["beacon:staff"])
+        self.assertEqual(api.resolve_groups("chat", user_id=2), [])
+
+    def test_role_lookup_failures_fail_closed(self):
+        api = PolicyAPI()
+        api.register_namespace("chat", plugin=True)
+        api.bind_group_role("chat", "admins", "role-admin")
+        api.set_group_rule("chat", "admins", "chat.command.shutdown", "allow")
+
+        def broken_resolver(namespace, user_id):
+            raise RuntimeError("role provider timeout")
+
+        api.set_role_resolver(broken_resolver)
+        self.assertFalse(api.evaluate("chat", "chat.command.shutdown", user_id=9))
+
+    def test_group_runtime_resolution_sanity(self):
+        api = PolicyAPI()
+        api.register_namespace("chat", plugin=True)
+        api.upsert_group("chat", "g1", members=["7"])
+        api.upsert_group("chat", "g2", members=["7"])
+        api.upsert_group("chat", "g3", role_ids=["role3"])
+
+        for _ in range(200):
+            groups = api.resolve_groups("chat", user_id=7, role_ids=["role3"])
+            self.assertEqual(groups, ["chat:g1", "chat:g2", "chat:g3"])
+
     def test_channel_policy_behavior_migrates_via_policy_api(self):
         sonata = FakeSonata()
         policies = ChannelPolicies(sonata)

--- a/tests/test_policy_api.py
+++ b/tests/test_policy_api.py
@@ -235,6 +235,31 @@ class PolicyApiTests(unittest.TestCase):
             )
         )
 
+    def test_group_state_persists_across_channel_policies_reload(self):
+        sonata = FakeSonata()
+        policies = ChannelPolicies(sonata)
+        policies.upsert_user_group("mods", members=["7"], role_ids=["role-admin"])
+        policies.deny_group_command("mods", "ban")
+
+        sonata.policy_api = None
+        reloaded = ChannelPolicies(sonata)
+        self.assertEqual(
+            reloaded.policy_api.get_group("chat", "mods"),
+            {
+                "id": "chat:mods",
+                "members": ["7"],
+                "roles": ["role-admin"],
+            },
+        )
+        self.assertFalse(
+            reloaded.is_command_allowed(
+                guild_id=1,
+                channel_id=10,
+                user_id=7,
+                command="ban",
+            )
+        )
+
     def test_precedence_user_channel_guild_and_namespace_isolation(self):
         api = PolicyAPI()
         api.register_namespace("chat", plugin=True)


### PR DESCRIPTION
## Summary
- Add persisted user-scope policy records and user CRUD helpers in the shared channel policy manager.
- Integrate group-targeted and role-derived user evaluation paths into chat authorization checks.
- Add tests for direct user policy, group-targeted effects, precedence interactions, and namespace safety.

## Why
User scope is the top layer in policy precedence and is needed for explicit per-user controls without duplicating policy logic in plugins.