### PR TITLE
SONA-48: Route beacon encryption targeting through Policy API

### DIFF
--- a/src/modules/plugins/beacon.py
+++ b/src/modules/plugins/beacon.py
@@ -22,10 +22,12 @@ from modules.utils import (
     settings,
 )
 from modules.AI_manager import AI_Manager
+from modules.policy_api import get_or_create_policy_api
 from typing import Literal
 
 import pickle
 import os
+import re
 import shutil
 from cryptography.fernet import Fernet
 
@@ -34,6 +36,7 @@ __plugin_name__ = "beacon"
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 SaveType = Literal["m", "c", None]
+GLOBAL_POLICY_SCOPE_ID = "__global__"
 
 
 def can_delete_folder(folder_path):
@@ -74,7 +77,33 @@ def beacon(sonata: AI_Manager):
         def __init__(self, path: str = "beacon-mainland", key: bytes | None = None):
             """Initialize the Beacon with a home folder and optional encryption key"""
             self.key = key
+            self.policy_api = get_or_create_policy_api(sonata)
+            if not self.policy_api.has_namespace("beacon"):
+                self.policy_api.register_namespace("beacon", plugin=True)
             self.light_house(path, True)
+
+        def _normalize_policy_path(self, path: str) -> str:
+            normalized = str(path or "").strip().replace("\\", "/")
+            normalized = re.sub(r"/+", "/", normalized)
+            normalized = normalized.strip("/").lower()
+            return normalized
+
+        def _path_action(self, path: str) -> str:
+            normalized_path = self._normalize_policy_path(path)
+            return f"beacon.encrypt.path.{normalized_path}"
+
+        def _resolve_encryption(
+            self, encrypted: bool, encrypted_path: str | None
+        ) -> bool:
+            if encrypted_path is None:
+                return bool(encrypted)
+            action = self._path_action(encrypted_path)
+            return self.policy_api.evaluate(
+                "beacon",
+                action,
+                guild_id=GLOBAL_POLICY_SCOPE_ID,
+                default=bool(encrypted),
+            )
 
         def _get_fernet(self):
             if not self.key:
@@ -117,6 +146,7 @@ def beacon(sonata: AI_Manager):
             data: any = None,
             remember: SaveType = None,
             encrypted: bool = False,
+            encrypted_path: str | None = None,
         ):
             """Save data to a file"""
             if remember != None:
@@ -128,7 +158,11 @@ def beacon(sonata: AI_Manager):
 
             with open(f"{self.home}/{name}.p", "wb") as f:
                 pickled_data = pickle.dumps(data)
-                if encrypted:
+                should_encrypt = self._resolve_encryption(
+                    encrypted,
+                    encrypted_path or f"{self.home}/{name}",
+                )
+                if should_encrypt:
                     fernet = self._get_fernet()
                     pickled_data = fernet.encrypt(pickled_data)
                 f.write(pickled_data)
@@ -141,6 +175,7 @@ def beacon(sonata: AI_Manager):
             data: dict,
             remember: SaveType = None,
             encrypted: bool = False,
+            encrypted_path: str | None = None,
         ):
             """Save module to a file"""
             if remember != None:
@@ -165,16 +200,31 @@ def beacon(sonata: AI_Manager):
                 else:
                     t = "s"
 
-                lamp_post.guide(f"{t}{key}", value, encrypted=encrypted)
+                path = encrypted_path or f"{self.home}/{module_name}/{t}{key}"
+                lamp_post.guide(
+                    f"{t}{key}",
+                    value,
+                    encrypted=encrypted,
+                    encrypted_path=path,
+                )
 
             return self
 
-        def locate(self, name: str, encrypted: bool = False):
+        def locate(
+            self,
+            name: str,
+            encrypted: bool = False,
+            encrypted_path: str | None = None,
+        ):
             """Load data from a file"""
             try:
                 with open(f"{self.home}/{name}.p", "rb") as f:
                     data = f.read()
-                    if encrypted:
+                    should_encrypt = self._resolve_encryption(
+                        encrypted,
+                        encrypted_path or f"{self.home}/{name}",
+                    )
+                    if should_encrypt:
                         fernet = self._get_fernet()
                         data = fernet.decrypt(data)
                     return pickle.loads(data)
@@ -185,7 +235,12 @@ def beacon(sonata: AI_Manager):
                 )
                 return
 
-        def discover(self, module_name: str, encrypted: bool = False):
+        def discover(
+            self,
+            module_name: str,
+            encrypted: bool = False,
+            encrypted_path: str | None = None,
+        ):
             """Load module from a file"""
             lamp_post = self.branch(module_name)
             data = {}
@@ -201,7 +256,12 @@ def beacon(sonata: AI_Manager):
                         key = bool(key[1:])
                     case "s":
                         key = str(key[1:])
-                data[key] = lamp_post.locate(i, encrypted=encrypted)
+                path = encrypted_path or f"{self.home}/{module_name}/{i}"
+                data[key] = lamp_post.locate(
+                    i,
+                    encrypted=encrypted,
+                    encrypted_path=path,
+                )
             return data
 
         def reflect(

--- a/src/modules/plugins/beacon.py
+++ b/src/modules/plugins/beacon.py
@@ -78,7 +78,9 @@ def beacon(sonata: AI_Manager):
             """Initialize the Beacon with a home folder and optional encryption key"""
             self.key = key
             self.policy_api = get_or_create_policy_api(sonata)
-            if not self.policy_api.has_namespace("beacon"):
+            if self.policy_api.has_namespace("beacon"):
+                self.policy_api.activate_namespace("beacon")
+            else:
                 self.policy_api.register_namespace("beacon", plugin=True)
             self.light_house(path, True)
 

--- a/tests/test_beacon_policy.py
+++ b/tests/test_beacon_policy.py
@@ -1,0 +1,173 @@
+import importlib.util
+import pathlib
+import pickle
+import shutil
+import sys
+import types
+import unittest
+import uuid
+
+
+def _load_beacon_module():
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    src_root = repo_root / "src"
+    if str(src_root) not in sys.path:
+        sys.path.insert(0, str(src_root))
+
+    module_path = src_root / "modules" / "plugins" / "beacon.py"
+    spec = importlib.util.spec_from_file_location("beacon_plugin", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load beacon module spec")
+
+    utils_stub = types.ModuleType("modules.utils")
+    utils_stub.async_cprint = lambda *_, **__: None
+    utils_stub.settings = types.SimpleNamespace(BEACON_ENCRYPTION_KEY=None)
+
+    class _ManagerStub:
+        @staticmethod
+        def builder(func):
+            return func
+
+    class _AIManagerStub:
+        @staticmethod
+        def init(*_, **__):
+            return None, _ManagerStub(), None
+
+    ai_manager_stub = types.ModuleType("modules.AI_manager")
+    ai_manager_stub.AI_Manager = _AIManagerStub
+
+    class _FernetStub:
+        def __init__(self, _key):
+            pass
+
+        @staticmethod
+        def generate_key():
+            return b"test-key"
+
+        def encrypt(self, payload):
+            return b"enc:" + payload
+
+        def decrypt(self, payload):
+            if not payload.startswith(b"enc:"):
+                raise ValueError("payload not encrypted")
+            return payload[4:]
+
+    cryptography_stub = types.ModuleType("cryptography")
+    cryptography_fernet_stub = types.ModuleType("cryptography.fernet")
+    cryptography_fernet_stub.Fernet = _FernetStub
+
+    original_utils = sys.modules.get("modules.utils")
+    original_ai_manager = sys.modules.get("modules.AI_manager")
+    original_cryptography = sys.modules.get("cryptography")
+    original_cryptography_fernet = sys.modules.get("cryptography.fernet")
+    sys.modules["modules.utils"] = utils_stub
+    sys.modules["modules.AI_manager"] = ai_manager_stub
+    sys.modules["cryptography"] = cryptography_stub
+    sys.modules["cryptography.fernet"] = cryptography_fernet_stub
+    try:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["beacon_plugin"] = module
+        spec.loader.exec_module(module)
+    finally:
+        if original_utils is None:
+            sys.modules.pop("modules.utils", None)
+        else:
+            sys.modules["modules.utils"] = original_utils
+        if original_ai_manager is None:
+            sys.modules.pop("modules.AI_manager", None)
+        else:
+            sys.modules["modules.AI_manager"] = original_ai_manager
+        if original_cryptography is None:
+            sys.modules.pop("cryptography", None)
+        else:
+            sys.modules["cryptography"] = original_cryptography
+        if original_cryptography_fernet is None:
+            sys.modules.pop("cryptography.fernet", None)
+        else:
+            sys.modules["cryptography.fernet"] = original_cryptography_fernet
+
+    return module
+
+
+class _FakeConfig:
+    def get(self, *_args, **_kwargs):
+        return None
+
+
+class _FakeSonata:
+    def __init__(self):
+        self.config = _FakeConfig()
+
+
+class BeaconPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.beacon_module = _load_beacon_module()
+        self.sonata = _FakeSonata()
+        beacon_class = self.beacon_module.beacon(self.sonata)
+        self.folder_name = f"beacon-policy-test-{uuid.uuid4().hex}"
+        self.beacon = beacon_class(path=self.folder_name, key=b"test-key")
+
+    def tearDown(self):
+        shutil.rmtree(self.beacon.home, ignore_errors=True)
+
+    def test_explicit_path_policy_match_encrypts_and_round_trips(self):
+        action = self.beacon._path_action(f"{self.beacon.home}/secret")
+        self.beacon.policy_api.set_rule(
+            "beacon",
+            "guild",
+            self.beacon_module.GLOBAL_POLICY_SCOPE_ID,
+            action,
+            "allow",
+        )
+
+        payload = {"message": "hello"}
+        self.beacon.guide("secret", payload, encrypted=False)
+        loaded = self.beacon.locate("secret", encrypted=False)
+        self.assertEqual(loaded, payload)
+
+    def test_non_match_falls_back_to_default_flag(self):
+        plain_payload = {"value": 1}
+        self.beacon.guide("plain", plain_payload, encrypted=False)
+        with open(f"{self.beacon.home}/plain.p", "rb") as handle:
+            raw_plain = handle.read()
+        self.assertEqual(pickle.loads(raw_plain), plain_payload)
+
+        encrypted_payload = {"value": 2}
+        self.beacon.guide("secure", encrypted_payload, encrypted=True)
+        with open(f"{self.beacon.home}/secure.p", "rb") as handle:
+            raw_encrypted = handle.read()
+        with self.assertRaises(Exception):
+            pickle.loads(raw_encrypted)
+        self.assertEqual(
+            self.beacon.locate("secure", encrypted=True), encrypted_payload
+        )
+
+    def test_path_normalization_is_case_and_separator_stable(self):
+        action = self.beacon._path_action(f"{self.beacon.home}\\NESTED/PATH")
+        self.beacon.policy_api.set_rule(
+            "beacon",
+            "guild",
+            self.beacon_module.GLOBAL_POLICY_SCOPE_ID,
+            action,
+            "allow",
+        )
+
+        payload = {"ok": True}
+        self.beacon.guide(
+            "norm",
+            payload,
+            encrypted=False,
+            encrypted_path=f"{self.beacon.home}/nested/path",
+        )
+        self.assertEqual(
+            self.beacon.locate(
+                "norm",
+                encrypted=False,
+                encrypted_path=f"{self.beacon.home}\\NESTED/PATH",
+            ),
+            payload,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_beacon_policy.py
+++ b/tests/test_beacon_policy.py
@@ -168,6 +168,29 @@ class BeaconPolicyTests(unittest.TestCase):
             payload,
         )
 
+    def test_beacon_reactivates_namespace_on_reuse(self):
+        action = self.beacon._path_action(f"{self.beacon.home}/secret")
+        self.beacon.policy_api.set_rule(
+            "beacon",
+            "guild",
+            self.beacon_module.GLOBAL_POLICY_SCOPE_ID,
+            action,
+            "allow",
+        )
+        self.beacon.policy_api.unload_namespace("beacon")
+
+        beacon_class = self.beacon_module.beacon(self.sonata)
+        second_folder = f"beacon-policy-test-{uuid.uuid4().hex}"
+        reloaded = beacon_class(path=second_folder, key=b"test-key")
+        self.addCleanup(shutil.rmtree, reloaded.home, True)
+
+        self.assertTrue(
+            reloaded._resolve_encryption(
+                False,
+                f"{self.beacon.home}/secret",
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Route beacon encryption decisions through Policy API namespace rules instead of ad-hoc path checks.
- Add normalized `encrypted_path` matching and fallback to the existing global encryption flag default.
- Add tests for explicit path match behavior, fallback behavior, and normalized path compatibility.

## Why
Beacon encryption targeting must be centrally policy-driven to preserve consistency, extensibility, and compatibility with existing save/load behavior.