### PR TITLE
SONA-67: Fix self-command image normalization

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -66,6 +66,50 @@ RUNTIME, _PLUGIN_EXTEND = load_config()
 def _ai_model(key: str, builtin_default: str) -> str:
     return resolve_ai_model(RUNTIME, key, builtin_default)
 
+
+def _normalize_image_inputs(config):
+    images = config.get("images")
+    if not images:
+        return None
+
+    if isinstance(images, dict):
+        channel_id = config.get("channel_id")
+        images = images.get(channel_id) or images.get(str(channel_id))
+        cprint(
+            f"Normalized dict image payload for channel {channel_id}: {0 if not images else len(images)} items",
+            "yellow",
+        )
+
+    if images is None:
+        return None
+
+    if isinstance(images, (str, bytes)):
+        images = [images]
+    elif not isinstance(images, list):
+        try:
+            images = list(images)
+        except TypeError:
+            cprint(f"Discarding unsupported image payload type: {type(images).__name__}", "red")
+            return None
+
+    valid_images = []
+    invalid_images = []
+    for item in images:
+        if item is True:
+            continue
+        if isinstance(item, str) and re.match(r"^https?://", item):
+            valid_images.append(item)
+        else:
+            invalid_images.append(item)
+
+    if invalid_images:
+        cprint(
+            f"Discarded invalid image payload entries: {invalid_images}",
+            "yellow",
+        )
+
+    return valid_images or None
+
 nest_asyncio.apply()
 
 if not discord.opus.is_loaded():
@@ -194,7 +238,7 @@ def DallE(client, prompt, model, config):
 )
 def Assistant(client, prompt, model, config):
     content = [{"type": "text", "text": prompt}]
-    i = config.get("images", False)
+    i = _normalize_image_inputs(config)
     if i:
         if model != "gpt-4o":
             model = "gpt-4-vision-preview"
@@ -273,7 +317,7 @@ def Grok(client: XAIClient, prompt, model, config):
 
     content = [prompt]
 
-    if images := config.get("images", False):
+    if images := _normalize_image_inputs(config):
         for url in images:
             if url is True:
                 continue
@@ -295,7 +339,7 @@ def Grok(client: XAIClient, prompt, model, config):
 )
 def OpenAI(client, prompt, model, config):
     content = [{"type": "text", "text": prompt}]
-    images = config.get("images", False)
+    images = _normalize_image_inputs(config)
 
     if images:
         images = [
@@ -332,7 +376,7 @@ def OpenAI(client, prompt, model, config):
 )
 def Claude(client, prompt, model, config):
     content = [{"type": "text", "text": prompt}]
-    i = config.get("images", False)
+    i = _normalize_image_inputs(config)
     instructions = (
         [
             {
@@ -473,7 +517,7 @@ def Gemini(client, prompt, model, config):
         },
     ]
     content = prompt
-    images = config.get("images", False)
+    images = _normalize_image_inputs(config)
     if images:
         # model = "gemini-1.5-flash"
         images = [Image.open(BytesIO(requests.get(u).content)) for u in images if u is not True]

--- a/src/index.py
+++ b/src/index.py
@@ -76,8 +76,8 @@ def _normalize_image_inputs(config):
         images = [images]
 
     valid_images = filter(
-        images, 
-        lambda image: isinstance(image, str) and re.match(r"^https?://", image)
+        lambda image: isinstance(image, str) and re.match(r"^https?://", image),
+        images
     )
 
     return list(valid_images) or None

--- a/src/index.py
+++ b/src/index.py
@@ -72,8 +72,9 @@ def _normalize_image_inputs(config):
     if not images or images is None:
         return None
 
-    if isinstance(images, (str, bytes)):
+    if isinstance(images, str):
         images = [images]
+
 
     valid_images = filter(
         lambda image: isinstance(image, str) and re.match(r"^https?://", image),

--- a/src/index.py
+++ b/src/index.py
@@ -69,46 +69,18 @@ def _ai_model(key: str, builtin_default: str) -> str:
 
 def _normalize_image_inputs(config):
     images = config.get("images")
-    if not images:
-        return None
-
-    if isinstance(images, dict):
-        channel_id = config.get("channel_id")
-        images = images.get(channel_id) or images.get(str(channel_id))
-        cprint(
-            f"Normalized dict image payload for channel {channel_id}: {0 if not images else len(images)} items",
-            "yellow",
-        )
-
-    if images is None:
+    if not images or images is None:
         return None
 
     if isinstance(images, (str, bytes)):
         images = [images]
-    elif not isinstance(images, list):
-        try:
-            images = list(images)
-        except TypeError:
-            cprint(f"Discarding unsupported image payload type: {type(images).__name__}", "red")
-            return None
 
-    valid_images = []
-    invalid_images = []
-    for item in images:
-        if item is True:
-            continue
-        if isinstance(item, str) and re.match(r"^https?://", item):
-            valid_images.append(item)
-        else:
-            invalid_images.append(item)
+    valid_images = filter(
+        images, 
+        lambda image: isinstance(image, str) and re.match(r"^https?://", image)
+    )
 
-    if invalid_images:
-        cprint(
-            f"Discarded invalid image payload entries: {invalid_images}",
-            "yellow",
-        )
-
-    return valid_images or None
+    return list(valid_images) or None
 
 nest_asyncio.apply()
 

--- a/src/modules/plugins/term-commands.py
+++ b/src/modules/plugins/term-commands.py
@@ -1447,6 +1447,9 @@ async def run_self_cmd(mem, bot, manager):
     history = manager.chat.get_history(c.id)
     # ai = client.config.get("AI")
     config = manager.config.copy()
+    image_map = config.get("images") or {}
+    config["channel_id"] = c.id
+    config["images"] = image_map.get(c.id) or image_map.get(str(c.id))
     command = await prompt("Enter self-command: ")
     args = await prompt("Enter args: ")
     config[

--- a/src/modules/plugins/term-commands.py
+++ b/src/modules/plugins/term-commands.py
@@ -1448,7 +1448,6 @@ async def run_self_cmd(mem, bot, manager):
     # ai = client.config.get("AI")
     config = manager.config.copy()
     image_map = config.get("images") or {}
-    config["channel_id"] = c.id
     config["images"] = image_map.get(c.id) or image_map.get(str(c.id))
     command = await prompt("Enter self-command: ")
     args = await prompt("Enter args: ")


### PR DESCRIPTION
## Summary
- normalize the terminal self-command flow so it passes only the current channel's queued image URLs into AI execution
- harden vision/image input handling in `src/index.py` so dict payloads are normalized by channel and invalid non-URL entries are discarded with diagnostics
- prevent self-command `$gif` and similar flows from treating Discord channel ids as URLs

## Root Cause
The terminal `cmd` self-command path copied the global config without normalizing `config["images"]`. In that shape, `images` could still be the full channel-id keyed dict, and downstream vision adapters iterated the dict keys as if they were image URLs. That produced errors like `Invalid URL '518671807503532062'` when a channel id reached `requests.get(...)`.

## Validation
- verified the self-command entry point now narrows `images` to the current channel before prompt execution
- verified the image adapters now normalize and filter image payloads before any network fetch
- attempted a compile check, but the local shell only has Python 3.9.6 while this repo already uses Python 3.10 `match` syntax, so that check is not runnable in this environment

Refs: SONA-67

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaqat/sonata/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
