### PR TITLE
SONA-72: Chat Protection Policies

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -43,6 +43,7 @@ from modules.channel_policies import (
     has_manage_guild_permission,
     resolve_channel_in_guild,
 )
+from modules.policy_admin import PolicyAdminError, get_or_create_policy_admin
 from modules.plugins import PLUGINS
 from modules.utils import (
     get_full_name,
@@ -1042,115 +1043,180 @@ def _resolve_text_channel(ctx, raw_channel):
     return channel, None
 
 
-@sonata.command(name="channels", description="Manage per-channel chat permissions.")
-async def channels(ctx, action="", *args):
+@sonata.command(name="policy", description="Manage policy rules across namespaces and scopes.")
+async def policy_cmd(ctx, action="", *args):
     action = action.lower().strip()
     if not has_manage_guild_permission(ctx):
         return await ctx_reply(
             ctx, "You need `Manage Server` permission to use this command."
         )
 
+    admin = get_or_create_policy_admin(Sonata)
+
     usage = (
         "Usage:\n"
-        "`$channels list`\n"
-        "`$channels show <channel_id|<#channel_id>>`\n"
-        "`$channels set <channel> <can_speak|respond_all> <true|false>`\n"
-        "`$channels allow <channel> <command>`\n"
-        "`$channels deny <channel> <command>`\n"
-        "`$channels blacklist <add|remove> <channel>`\n"
-        "`$channels remove <channel>`"
+        "`$policy namespaces`\n"
+        "`$policy show <namespace> <scope> <target>`\n"
+        "`$policy set <namespace> <scope> <target> <action> <allow|deny>`\n"
+        "`$policy remove <namespace> <scope> <target> <action>`\n"
+        "`$policy clear <namespace> <scope> <target>`\n"
+        "`$policy groups list <namespace>`\n"
+        "`$policy groups show <namespace> <group>`\n"
+        "`$policy groups upsert <namespace> <group> [members_csv|-] [roles_csv|-]`\n"
+        "`$policy groups remove <namespace> <group>`\n"
+        "`$policy groups member <add|remove> <namespace> <group> <user>`\n"
+        "`$policy groups role <add|remove> <namespace> <group> <role>`"
     )
 
     if action in {"", "help"}:
         return await ctx_reply(ctx, usage)
 
-    if action == "list":
-        channel_map = Sonata.chat.policy_manager.get_channels()
-        if not channel_map:
-            return await ctx_reply(ctx, "No channel overrides are configured.")
-
-        lines = []
-        for channel_id in sorted(channel_map.keys()):
-            lines.append(format_channel_policy(channel_id, channel_map[channel_id]))
-        return await ctx_reply(ctx, "\n".join(lines[:30]))
-
-    if action == "show":
-        if len(args) < 1:
-            return await ctx_reply(ctx, usage)
-        channel, error = _resolve_text_channel(ctx, args[0])
-        if error:
-            return await ctx_reply(ctx, error)
-        policy = Sonata.chat.policy_manager.get_channel_policy(channel.id)
-        return await ctx_reply(ctx, format_channel_policy(channel.id, policy))
-
-    if action == "remove":
-        if len(args) < 1:
-            return await ctx_reply(ctx, usage)
-        channel, error = _resolve_text_channel(ctx, args[0])
-        if error:
-            return await ctx_reply(ctx, error)
-        removed = Sonata.chat.policy_manager.remove_channel_policy(channel.id)
-        if removed is None:
-            return await ctx_reply(ctx, f"No override existed for `{channel.id}`.")
-        return await ctx_reply(ctx, f"Removed override for `{channel.id}`.")
-
-    if action in {"set", "allow", "deny", "blacklist"}:
-        if action == "blacklist":
-            if len(args) < 2:
-                return await ctx_reply(ctx, usage)
-            sub_action = args[0].lower().strip()
-            channel_arg = args[1]
-            channel, error = _resolve_text_channel(ctx, channel_arg)
-            if error:
-                return await ctx_reply(ctx, error)
-
-            if sub_action == "add":
-                policy = Sonata.chat.policy_manager.blacklist_add(channel.id)
-                return await ctx_reply(
-                    ctx,
-                    f"Blacklisted `{channel.id}`.\n{format_channel_policy(channel.id, policy)}",
-                )
-            if sub_action == "remove":
-                policy = Sonata.chat.policy_manager.blacklist_remove(channel.id)
-                return await ctx_reply(
-                    ctx,
-                    f"Un-blacklisted `{channel.id}`.\n{format_channel_policy(channel.id, policy)}",
-                )
-            return await ctx_reply(ctx, usage)
-
-        if len(args) < 2:
-            return await ctx_reply(ctx, usage)
-
-        channel, error = _resolve_text_channel(ctx, args[0])
-        if error:
-            return await ctx_reply(ctx, error)
-
-        if action == "set":
-            if len(args) < 3:
-                return await ctx_reply(ctx, usage)
-            field = args[1].lower().strip()
-            if field not in {"can_speak", "respond_all"}:
-                return await ctx_reply(
-                    ctx, "Field must be `can_speak` or `respond_all`."
-                )
-            try:
-                value = parse_bool(args[2])
-            except ValueError:
-                return await ctx_reply(ctx, "Value must be true/false.")
-            policy = Sonata.chat.policy_manager.set_channel_flag(channel.id, field, value)
-            return await ctx_reply(ctx, format_channel_policy(channel.id, policy))
-
-        command_name = args[1].lower().strip().lstrip("$")
-        if not command_name:
-            return await ctx_reply(ctx, "Command cannot be empty.")
-
-        if action == "allow":
-            policy = Sonata.chat.policy_manager.allow_command(channel.id, command_name)
-        else:
-            policy = Sonata.chat.policy_manager.deny_command(channel.id, command_name)
-        return await ctx_reply(ctx, format_channel_policy(channel.id, policy))
+    try:
+        result = await _handle_policy_action(ctx, admin, action, args, usage)
+        if result is not None:
+            return await ctx_reply(ctx, result)
+    except PolicyAdminError as e:
+        return await ctx_reply(ctx, str(e))
 
     await ctx_reply(ctx, usage)
+
+
+async def _handle_policy_action(ctx, admin, action, args, usage):
+    if action == "namespaces":
+        ns_list = admin.list_namespaces()
+        return "Namespaces: " + ", ".join(f"`{n}`" for n in ns_list)
+
+    if action == "show":
+        if len(args) < 3:
+            return usage
+        namespace, scope, target = args[0], args[1], args[2]
+        target = _resolve_discord_target(ctx, scope, target)
+        return admin.show_rules(namespace, scope, target)
+
+    if action == "set":
+        if len(args) < 5:
+            return usage
+        namespace, scope, target, act, effect = args[0], args[1], args[2], args[3], args[4]
+        target = _resolve_discord_target(ctx, scope, target)
+        return admin.set_rule(namespace, scope, target, act, effect)
+
+    if action == "remove":
+        if len(args) < 4:
+            return usage
+        namespace, scope, target, act = args[0], args[1], args[2], args[3]
+        target = _resolve_discord_target(ctx, scope, target)
+        return admin.remove_rule(namespace, scope, target, act)
+
+    if action == "clear":
+        if len(args) < 3:
+            return usage
+        namespace, scope, target = args[0], args[1], args[2]
+        target = _resolve_discord_target(ctx, scope, target)
+        return admin.clear_scope(namespace, scope, target)
+
+    if action == "groups":
+        return _handle_policy_groups(ctx, admin, args, usage)
+
+    return None
+
+
+def _handle_policy_groups(ctx, admin, args, usage):
+    if len(args) < 2:
+        return usage
+    sub = args[0].lower()
+
+    if sub == "list":
+        return admin.list_groups(args[1])
+
+    if sub == "show":
+        if len(args) < 3:
+            return usage
+        return admin.show_group(args[1], args[2])
+
+    if sub == "upsert":
+        if len(args) < 3:
+            return usage
+        namespace, group = args[1], args[2]
+        members = args[3] if len(args) > 3 else None
+        roles = args[4] if len(args) > 4 else None
+        return admin.upsert_group(namespace, group, members=members, role_ids=roles)
+
+    if sub == "remove":
+        if len(args) < 3:
+            return usage
+        return admin.remove_group(args[1], args[2])
+
+    if sub == "member":
+        if len(args) < 5:
+            return usage
+        op, namespace, group, user = args[1], args[2], args[3], args[4]
+        user_id = _resolve_discord_user_id(user)
+        if op == "add":
+            return admin.add_group_member(namespace, group, user_id)
+        if op == "remove":
+            return admin.remove_group_member(namespace, group, user_id)
+        return usage
+
+    if sub == "role":
+        if len(args) < 5:
+            return usage
+        op, namespace, group, role = args[1], args[2], args[3], args[4]
+        role_id = _resolve_discord_role_id(role)
+        if op == "add":
+            return admin.add_group_role(namespace, group, role_id)
+        if op == "remove":
+            return admin.remove_group_role(namespace, group, role_id)
+        return usage
+
+    return usage
+
+
+def _resolve_discord_target(ctx, scope, raw_target):
+    """Resolve Discord-specific target references like 'here', <#channel>, <@user>."""
+    raw = str(raw_target).strip()
+    scope_lower = scope.lower()
+
+    if raw.lower() == "here" and scope_lower == "channel":
+        return str(ctx.channel.id)
+
+    if raw.lower() == "here" and scope_lower == "guild":
+        guild = getattr(ctx, "guild", None)
+        if guild:
+            return str(guild.id)
+
+    # <#channel_id>
+    if raw.startswith("<#") and raw.endswith(">"):
+        return raw[2:-1]
+
+    # <@user_id> or <@!user_id>
+    if raw.startswith("<@") and raw.endswith(">"):
+        inner = raw[2:-1]
+        if inner.startswith("!"):
+            inner = inner[1:]
+        return inner
+
+    # <@&role_id>
+    if raw.startswith("<@&") and raw.endswith(">"):
+        return raw[3:-1]
+
+    return raw
+
+
+def _resolve_discord_user_id(raw):
+    raw = str(raw).strip()
+    if raw.startswith("<@") and raw.endswith(">"):
+        inner = raw[2:-1]
+        if inner.startswith("!"):
+            inner = inner[1:]
+        return inner
+    return raw
+
+
+def _resolve_discord_role_id(raw):
+    raw = str(raw).strip()
+    if raw.startswith("<@&") and raw.endswith(">"):
+        return raw[3:-1]
+    return raw
 
 
 # TODO: Refactor emoji archiving to a separate util file

--- a/src/modules/channel_policies.py
+++ b/src/modules/channel_policies.py
@@ -98,12 +98,14 @@ class ChannelPolicy:
     # Stored shape for one guild/channel/user policy row (mirrored into PolicyAPI "chat" rules).
     can_speak: bool = True
     respond_all: bool = False
+    protected: bool = False
     command_policy_mode: str = DENYLIST
     commands: list[str] | None = None
 
     def __post_init__(self):
         self.can_speak = bool(self.can_speak)
         self.respond_all = bool(self.respond_all)
+        self.protected = bool(self.protected)
         if self.command_policy_mode not in {ALLOWLIST, DENYLIST}:
             self.command_policy_mode = DENYLIST
         self.commands = normalize_commands(self.commands)
@@ -113,6 +115,7 @@ class ChannelPolicy:
         return cls(
             can_speak=True,
             respond_all=False,
+            protected=False,
             command_policy_mode=DENYLIST,
             commands=[],
         )
@@ -133,6 +136,7 @@ class ChannelPolicy:
             return cls(
                 can_speak=policy.can_speak,
                 respond_all=policy.respond_all,
+                protected=policy.protected,
                 command_policy_mode=policy.command_policy_mode,
                 commands=policy.commands,
             )
@@ -143,6 +147,7 @@ class ChannelPolicy:
         return cls(
             can_speak=policy.get("can_speak", True),
             respond_all=policy.get("respond_all", False),
+            protected=policy.get("protected", False),
             command_policy_mode=policy.get("command_policy_mode", DENYLIST),
             commands=policy.get("commands", []),
         )
@@ -151,6 +156,7 @@ class ChannelPolicy:
         return {
             "can_speak": self.can_speak,
             "respond_all": self.respond_all,
+            "protected": self.protected,
             "command_policy_mode": self.command_policy_mode,
             "commands": list(self.commands),
         }
@@ -202,6 +208,7 @@ class ChannelPolicy:
         return (
             f"can_speak={self.can_speak}, "
             f"respond_all={self.respond_all}, "
+            f"protected={self.protected}, "
             f"command_policy_mode={self.command_policy_mode}, "
             f"commands=[{commands}]"
         )
@@ -219,6 +226,8 @@ class ChannelPolicies:
         self.loaded = False
         self.policy_api = get_or_create_policy_api(sonata)
         self._ensure_chat_namespace()
+        self._ensure_beacon_namespace()
+        self.init()
 
     def _ensure_chat_namespace(self):
         if self.policy_api.has_namespace("chat"):
@@ -231,9 +240,116 @@ class ChannelPolicies:
             default_decisions={
                 "chat.can_speak": True,
                 "chat.respond_all": False,
+                "chat.protected": False,
                 "chat.command.*": True,
             },
         )
+
+    def _has_beacon(self):
+        has_method = getattr(self.sonata, "has", None)
+        if callable(has_method):
+            try:
+                return bool(has_method("beacon"))
+            except Exception:
+                return hasattr(self.sonata, "beacon")
+        return hasattr(self.sonata, "beacon")
+
+    def _ensure_beacon_namespace(self):
+        if not self._has_beacon():
+            return
+        if self.policy_api.has_namespace("beacon"):
+            self.policy_api.activate_namespace("beacon")
+            return
+        self.policy_api.register_namespace("beacon", plugin=True)
+
+    def _beacon_chat_history_action(self, channel_id):
+        if not self._has_beacon():
+            return None
+        beacon_home = getattr(getattr(self.sonata, "beacon", None), "home", None)
+        if not beacon_home:
+            return None
+        beacon_home = str(beacon_home)
+        normalized = beacon_home.replace("\\", "/").strip("/").lower()
+        return f"beacon.encrypt.path.{normalized}/chat/value/i{channel_id}"
+
+    def _policy_from_scope_rules(self, scope, scope_id):
+        rules = self.policy_api.get_scope_rules("chat", scope, scope_id)
+        if not rules:
+            return None
+
+        policy = ChannelPolicy.default()
+        allowed_commands = []
+        denied_commands = []
+        allowlist_mode = False
+
+        for rule in rules:
+            if rule.action == "chat.can_speak":
+                policy.can_speak = rule.effect != EFFECT_DENY
+            elif rule.action == "chat.respond_all":
+                policy.respond_all = rule.effect == EFFECT_ALLOW
+            elif rule.action == "chat.protected":
+                policy.protected = rule.effect == EFFECT_ALLOW
+            elif rule.action == "chat.command.*":
+                allowlist_mode = rule.effect == EFFECT_DENY
+            elif rule.action.startswith("chat.command."):
+                command = normalize_command_name(rule.action.removeprefix("chat.command."))
+                if not command:
+                    continue
+                if rule.effect == EFFECT_ALLOW:
+                    allowed_commands.append(command)
+                else:
+                    denied_commands.append(command)
+
+        if allowlist_mode:
+            policy.command_policy_mode = ALLOWLIST
+            policy.commands = normalize_commands(allowed_commands)
+        else:
+            policy.command_policy_mode = DENYLIST
+            policy.commands = normalize_commands(denied_commands)
+
+        return policy
+
+    def refresh_from_policy_api(self):
+        chat_rules = self.policy_api._rules.get("chat", {})
+        old_channel_ids = set(self.channels.keys())
+
+        guilds = {}
+        for scope_id in chat_rules.get("guild", {}):
+            policy = self._policy_from_scope_rules("guild", scope_id)
+            if policy is not None:
+                guilds[str(scope_id)] = policy
+
+        users = {}
+        for scope_id in chat_rules.get("user", {}):
+            policy = self._policy_from_scope_rules("user", scope_id)
+            if policy is not None:
+                users[str(scope_id)] = policy
+
+        channels = {}
+        for scope_id in chat_rules.get("channel", {}):
+            policy = self._policy_from_scope_rules("channel", scope_id)
+            if policy is not None:
+                channels[str(scope_id)] = policy
+
+        self.guilds = guilds
+        self.users = users
+        self.channels = channels
+        self.loaded = True
+
+        if self._has_beacon() and self.policy_api.has_namespace("beacon"):
+            for channel_id in old_channel_ids.union(channels.keys()):
+                beacon_action = self._beacon_chat_history_action(channel_id)
+                if beacon_action is not None:
+                    self.policy_api.remove_rule(
+                        "beacon", "guild", "__global__", beacon_action
+                    )
+
+        for guild_id, policy in self.guilds.items():
+            self._sync_guild_scope(guild_id, policy)
+        for user_id, policy in self.users.items():
+            self._sync_user_scope(user_id, policy)
+        for channel_id, policy in self.channels.items():
+            self._sync_channel_scope(channel_id, policy)
 
     def _sync_channel_scope(self, channel_id, policy):
         key = str(channel_id)
@@ -251,6 +367,11 @@ class ChannelPolicies:
         policy = ChannelPolicy.normalize(policy)
         # Full replace for this scope id so removed commands disappear from PolicyAPI
         self.policy_api.clear_scope("chat", scope, scope_id)
+        beacon_action = None
+        if scope == "channel":
+            beacon_action = self._beacon_chat_history_action(scope_id)
+            if beacon_action is not None and self.policy_api.has_namespace("beacon"):
+                self.policy_api.remove_rule("beacon", "guild", "__global__", beacon_action)
 
         if not policy.can_speak:
             self.policy_api.set_rule(
@@ -262,6 +383,19 @@ class ChannelPolicies:
             self.policy_api.set_rule(
                 "chat", scope, scope_id, "chat.respond_all", EFFECT_ALLOW
             )
+
+        if policy.protected:
+            self.policy_api.set_rule(
+                "chat", scope, scope_id, "chat.protected", EFFECT_ALLOW
+            )
+            if beacon_action is not None and self.policy_api.has_namespace("beacon"):
+                self.policy_api.set_rule(
+                    "beacon",
+                    "guild",
+                    "__global__",
+                    beacon_action,
+                    EFFECT_ALLOW,
+                )
 
         if policy.command_policy_mode == DENYLIST:
             for command in policy.commands:
@@ -414,7 +548,7 @@ class ChannelPolicies:
             users=serialized_users,
             groups=serialized_groups,
         )
-        if self.sonata.has("beacon"):
+        if self._has_beacon():
             policies_branch = self.sonata.beacon.branch("policies")
             policies_branch.illuminate("channels", serialized_channels)
             policies_branch.illuminate("guilds", serialized_guilds)
@@ -422,11 +556,13 @@ class ChannelPolicies:
             policies_branch.illuminate("groups", serialized_groups)
 
     def init(self):
+        if self.loaded:
+            return self.channels
         beacon_channels = {}
         beacon_guilds = {}
         beacon_users = {}
         beacon_groups = {}
-        if self.sonata.has("beacon"):
+        if self._has_beacon():
             policies_branch = self.sonata.beacon.branch("policies")
             beacon_channels = policies_branch.discover("channels") or {}
             beacon_guilds = policies_branch.discover("guilds") or {}
@@ -670,8 +806,8 @@ class ChannelPolicies:
         return removed.clone() if removed is not None else None
 
     def set_channel_flag(self, channel_id, key, value):
-        if key not in {"can_speak", "respond_all"}:
-            raise ValueError("Channel flag must be can_speak or respond_all")
+        if key not in {"can_speak", "respond_all", "protected"}:
+            raise ValueError("Channel flag must be can_speak, respond_all or protected")
         return self.set_channel_policy(channel_id, **{key: bool(value)})
 
     def allow_command(self, channel_id, command):
@@ -737,6 +873,25 @@ class ChannelPolicies:
         return self.policy_api.evaluate(
             "chat",
             "chat.respond_all",
+            guild_id=guild_id,
+            channel_id=channel_id,
+            user_id=user_id,
+            role_ids=role_ids,
+            group_ids=group_ids,
+            default=False,
+        )
+
+    def is_protected(
+        self,
+        guild_id,
+        channel_id,
+        user_id=None,
+        role_ids=None,
+        group_ids=None,
+    ):
+        return self.policy_api.evaluate(
+            "chat",
+            "chat.protected",
             guild_id=guild_id,
             channel_id=channel_id,
             user_id=user_id,

--- a/src/modules/channel_policies.py
+++ b/src/modules/channel_policies.py
@@ -96,7 +96,12 @@ def should_respond_to_message(
 def _is_canonical_chat_action(action):
     # Specific chat.command.<name> allows may be preserved via extra_rules in
     # denylist mode; only the structural/wildcard actions are reserved here.
-    return action in {"chat.can_speak", "chat.respond_all", "chat.command.*"}
+    return action in {
+        "chat.can_speak",
+        "chat.respond_all",
+        "chat.protected",
+        "chat.command.*",
+    }
 
 
 def _normalize_extra_rules(extra_rules):
@@ -126,6 +131,7 @@ class ChannelPolicy:
     # Stored shape for one guild/channel/user policy row (mirrored into PolicyAPI "chat" rules).
     can_speak: bool = True
     respond_all: bool = False
+    protected: bool = False
     command_policy_mode: str = DENYLIST
     commands: list[str] | None = None
     # Non-standard chat.* actions preserved across PolicyAPI ↔ ChannelPolicies round-trips.
@@ -134,6 +140,7 @@ class ChannelPolicy:
     def __post_init__(self):
         self.can_speak = bool(self.can_speak)
         self.respond_all = bool(self.respond_all)
+        self.protected = bool(self.protected)
         if self.command_policy_mode not in {ALLOWLIST, DENYLIST}:
             self.command_policy_mode = DENYLIST
         self.commands = normalize_commands(self.commands)
@@ -144,6 +151,7 @@ class ChannelPolicy:
         return cls(
             can_speak=True,
             respond_all=False,
+            protected=False,
             command_policy_mode=DENYLIST,
             commands=[],
             extra_rules=[],
@@ -155,6 +163,7 @@ class ChannelPolicy:
         return cls(
             can_speak=False,
             respond_all=False,
+            protected=False,
             command_policy_mode=ALLOWLIST,
             commands=[],
             extra_rules=[],
@@ -166,6 +175,7 @@ class ChannelPolicy:
             return cls(
                 can_speak=policy.can_speak,
                 respond_all=policy.respond_all,
+                protected=policy.protected,
                 command_policy_mode=policy.command_policy_mode,
                 commands=policy.commands,
                 extra_rules=policy.extra_rules,
@@ -177,6 +187,7 @@ class ChannelPolicy:
         return cls(
             can_speak=policy.get("can_speak", True),
             respond_all=policy.get("respond_all", False),
+            protected=policy.get("protected", False),
             command_policy_mode=policy.get("command_policy_mode", DENYLIST),
             commands=policy.get("commands", []),
             extra_rules=policy.get("extra_rules", []),
@@ -186,6 +197,7 @@ class ChannelPolicy:
         data = {
             "can_speak": self.can_speak,
             "respond_all": self.respond_all,
+            "protected": self.protected,
             "command_policy_mode": self.command_policy_mode,
             "commands": list(self.commands),
         }
@@ -240,6 +252,7 @@ class ChannelPolicy:
         return (
             f"can_speak={self.can_speak}, "
             f"respond_all={self.respond_all}, "
+            f"protected={self.protected}, "
             f"command_policy_mode={self.command_policy_mode}, "
             f"commands=[{commands}]"
         )
@@ -257,6 +270,7 @@ class ChannelPolicies:
         self.loaded = False
         self.policy_api = get_or_create_policy_api(sonata)
         self._ensure_chat_namespace()
+        self._ensure_beacon_namespace()
         self.init()
 
     def _ensure_chat_namespace(self):
@@ -270,6 +284,7 @@ class ChannelPolicies:
             default_decisions={
                 "chat.can_speak": True,
                 "chat.respond_all": False,
+                "chat.protected": False,
                 "chat.command.*": True,
             },
         )
@@ -282,6 +297,24 @@ class ChannelPolicies:
             except Exception:
                 return hasattr(self.sonata, "beacon")
         return hasattr(self.sonata, "beacon")
+
+    def _ensure_beacon_namespace(self):
+        if not self._has_beacon():
+            return
+        if self.policy_api.has_namespace("beacon"):
+            self.policy_api.activate_namespace("beacon")
+            return
+        self.policy_api.register_namespace("beacon", plugin=True)
+
+    def _beacon_chat_history_action(self, channel_id):
+        if not self._has_beacon():
+            return None
+        beacon_home = getattr(getattr(self.sonata, "beacon", None), "home", None)
+        if not beacon_home:
+            return None
+        beacon_home = str(beacon_home)
+        normalized = beacon_home.replace("\\", "/").strip("/").lower()
+        return f"beacon.encrypt.path.{normalized}/chat/value/i{channel_id}"
 
     def _policy_from_scope_rules(self, scope, scope_id):
         rules = self.policy_api.get_scope_rules("chat", scope, scope_id)
@@ -299,6 +332,8 @@ class ChannelPolicies:
                 policy.can_speak = rule.effect != EFFECT_DENY
             elif rule.action == "chat.respond_all":
                 policy.respond_all = rule.effect == EFFECT_ALLOW
+            elif rule.action == "chat.protected":
+                policy.protected = rule.effect == EFFECT_ALLOW
             elif rule.action == "chat.command.*":
                 allowlist_mode = rule.effect == EFFECT_DENY
             elif rule.action.startswith("chat.command."):
@@ -330,6 +365,8 @@ class ChannelPolicies:
 
     def refresh_from_policy_api(self):
         """Rebuild ChannelPolicies maps from PolicyAPI chat rules for persistence."""
+        old_channel_ids = set(self.channels.keys())
+
         guilds = {}
         for scope_id in self.policy_api.list_scope_ids("chat", "guild"):
             policy = self._policy_from_scope_rules("guild", scope_id)
@@ -352,6 +389,14 @@ class ChannelPolicies:
         self.users = users
         self.channels = channels
         self.loaded = True
+
+        if self._has_beacon() and self.policy_api.has_namespace("beacon"):
+            for channel_id in old_channel_ids.union(channels.keys()):
+                beacon_action = self._beacon_chat_history_action(channel_id)
+                if beacon_action is not None:
+                    self.policy_api.remove_rule(
+                        "beacon", "guild", "__global__", beacon_action
+                    )
 
         for guild_id, policy in self.guilds.items():
             self._sync_guild_scope(guild_id, policy)
@@ -376,6 +421,11 @@ class ChannelPolicies:
         policy = ChannelPolicy.normalize(policy)
         # Full replace for this scope id so removed commands disappear from PolicyAPI
         self.policy_api.clear_scope("chat", scope, scope_id)
+        beacon_action = None
+        if scope == "channel":
+            beacon_action = self._beacon_chat_history_action(scope_id)
+            if beacon_action is not None and self.policy_api.has_namespace("beacon"):
+                self.policy_api.remove_rule("beacon", "guild", "__global__", beacon_action)
 
         if not policy.can_speak:
             self.policy_api.set_rule(
@@ -387,6 +437,19 @@ class ChannelPolicies:
             self.policy_api.set_rule(
                 "chat", scope, scope_id, "chat.respond_all", EFFECT_ALLOW
             )
+
+        if policy.protected:
+            self.policy_api.set_rule(
+                "chat", scope, scope_id, "chat.protected", EFFECT_ALLOW
+            )
+            if beacon_action is not None and self.policy_api.has_namespace("beacon"):
+                self.policy_api.set_rule(
+                    "beacon",
+                    "guild",
+                    "__global__",
+                    beacon_action,
+                    EFFECT_ALLOW,
+                )
 
         if policy.command_policy_mode == DENYLIST:
             for command in policy.commands:
@@ -806,8 +869,8 @@ class ChannelPolicies:
         return removed.clone() if removed is not None else None
 
     def set_channel_flag(self, channel_id, key, value):
-        if key not in {"can_speak", "respond_all"}:
-            raise ValueError("Channel flag must be can_speak or respond_all")
+        if key not in {"can_speak", "respond_all", "protected"}:
+            raise ValueError("Channel flag must be can_speak, respond_all or protected")
         return self.set_channel_policy(channel_id, **{key: bool(value)})
 
     def allow_command(self, channel_id, command):
@@ -873,6 +936,25 @@ class ChannelPolicies:
         return self.policy_api.evaluate(
             "chat",
             "chat.respond_all",
+            guild_id=guild_id,
+            channel_id=channel_id,
+            user_id=user_id,
+            role_ids=role_ids,
+            group_ids=group_ids,
+            default=False,
+        )
+
+    def is_protected(
+        self,
+        guild_id,
+        channel_id,
+        user_id=None,
+        role_ids=None,
+        group_ids=None,
+    ):
+        return self.policy_api.evaluate(
+            "chat",
+            "chat.protected",
             guild_id=guild_id,
             channel_id=channel_id,
             user_id=user_id,

--- a/src/modules/channel_policies.py
+++ b/src/modules/channel_policies.py
@@ -312,9 +312,19 @@ class ChannelPolicies:
         beacon_home = getattr(getattr(self.sonata, "beacon", None), "home", None)
         if not beacon_home:
             return None
-        beacon_home = str(beacon_home)
-        normalized = beacon_home.replace("\\", "/").strip("/").lower()
+        # Match Beacon path normalization so encrypt rules evaluate against the same key.
+        normalized = re.sub(
+            r"/+", "/", str(beacon_home).replace("\\", "/")
+        ).strip("/").lower()
         return f"beacon.encrypt.path.{normalized}/chat/value/i{channel_id}"
+
+    def _clear_beacon_chat_history_rule(self, channel_id):
+        beacon_action = self._beacon_chat_history_action(channel_id)
+        if beacon_action is None or not self.policy_api.has_namespace("beacon"):
+            return
+        self.policy_api.remove_rule(
+            "beacon", "guild", "__global__", beacon_action
+        )
 
     def _policy_from_scope_rules(self, scope, scope_id):
         rules = self.policy_api.get_scope_rules("chat", scope, scope_id)
@@ -333,7 +343,8 @@ class ChannelPolicies:
             elif rule.action == "chat.respond_all":
                 policy.respond_all = rule.effect == EFFECT_ALLOW
             elif rule.action == "chat.protected":
-                policy.protected = rule.effect == EFFECT_ALLOW
+                if scope == "channel":
+                    policy.protected = rule.effect == EFFECT_ALLOW
             elif rule.action == "chat.command.*":
                 allowlist_mode = rule.effect == EFFECT_DENY
             elif rule.action.startswith("chat.command."):
@@ -438,7 +449,9 @@ class ChannelPolicies:
                 "chat", scope, scope_id, "chat.respond_all", EFFECT_ALLOW
             )
 
-        if policy.protected:
+        # Protection is channel-scoped so Beacon encrypt paths stay aligned with
+        # the privacy decision. Ignore protected flags on guild/user scopes.
+        if policy.protected and scope == "channel":
             self.policy_api.set_rule(
                 "chat", scope, scope_id, "chat.protected", EFFECT_ALLOW
             )
@@ -497,18 +510,24 @@ class ChannelPolicies:
     def _normalize_users_map(self, users):
         if not isinstance(users, dict):
             return {}
-        return {
-            str(user_id): ChannelPolicy.normalize(policy)
-            for user_id, policy in users.items()
-        }
+        normalized = {}
+        for user_id, policy in users.items():
+            policy = ChannelPolicy.normalize(policy)
+            if policy.protected:
+                policy = policy.with_updates(protected=False)
+            normalized[str(user_id)] = policy
+        return normalized
 
     def _normalize_guilds_map(self, guilds):
         if not isinstance(guilds, dict):
             return {}
-        return {
-            str(guild_id): ChannelPolicy.normalize(policy)
-            for guild_id, policy in guilds.items()
-        }
+        normalized = {}
+        for guild_id, policy in guilds.items():
+            policy = ChannelPolicy.normalize(policy)
+            if policy.protected:
+                policy = policy.with_updates(protected=False)
+            normalized[str(guild_id)] = policy
+        return normalized
 
     def _normalize_channels_map(self, channels):
         if not isinstance(channels, dict):
@@ -865,6 +884,7 @@ class ChannelPolicies:
         key = str(channel_id)
         removed = self.channels.pop(key, None)
         self.policy_api.clear_scope("chat", "channel", key)
+        self._clear_beacon_chat_history_rule(key)
         self._persist()
         return removed.clone() if removed is not None else None
 
@@ -952,14 +972,12 @@ class ChannelPolicies:
         role_ids=None,
         group_ids=None,
     ):
+        # Channel-only: privacy/logging must not be overridden by user/group rules,
+        # and Beacon encryption is keyed per channel path.
         return self.policy_api.evaluate(
             "chat",
             "chat.protected",
-            guild_id=guild_id,
             channel_id=channel_id,
-            user_id=user_id,
-            role_ids=role_ids,
-            group_ids=group_ids,
             default=False,
         )
 

--- a/src/modules/plugins/chat.py
+++ b/src/modules/plugins/chat.py
@@ -12,8 +12,9 @@ before running commands or AI flows: **can_speak**, per-command allow/deny (see
 ``command_policy_mode`` in ``channel_policies``), then **respond_all** for whether
 proactive replies are allowed. DMs are not gated by channel policy.
 
-Configure overrides via ``$channels`` (Discord) or ``channels`` (terminal); see
-``channel_policies`` module docstring.
+Configure overrides via ``$policy`` (Discord) or ``policy`` (terminal); see
+``policy_admin`` module docstring. ``$policy`` bypasses channel gating so admins
+can recover access from disabled channels.
 """
 
 # TODO: Make  message class
@@ -245,13 +246,17 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
     command_name = get_command_name(message.content)
     is_command = bool(command_name)
     role_ids = [str(role.id) for role in getattr(message.author, "roles", [])]
+
+    # $policy bypasses all chat policy gating so admins can recover access
+    is_policy_command = command_name == "policy"
+
     can_speak = policy_manager.can_speak(
         guild_id=message.guild.id,
         channel_id=message.channel.id,
         user_id=message.author.id,
         role_ids=role_ids,
     )
-    if not can_speak:
+    if not can_speak and not is_policy_command:
         if is_command:
             await message.reply(
                 "Sonata is disabled in this channel.",
@@ -260,7 +265,7 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
         cprint(f"Sona blocked by channel policy in {message.channel.name}", "yellow")
         return
 
-    if is_command and not policy_manager.is_command_allowed(
+    if is_command and not is_policy_command and not policy_manager.is_command_allowed(
         guild_id=message.guild.id,
         channel_id=message.channel.id,
         user_id=message.author.id,
@@ -569,6 +574,11 @@ def chat(sona: AI_Manager):
     prompt_manager = sona.prompt_manager
     policy_manager = ChannelPolicies(sona)
     policy_manager.init()
+
+    # Load persisted generic namespace state (core, beacon, etc.) after chat init
+    from modules.policy_admin import get_or_create_policy_admin
+    policy_admin = get_or_create_policy_admin(sona)
+    policy_admin.load_all_namespaces()
 
     # TODO: Make way to translate history into proper chat log format for each AI
     # https://github.com/users/bIaqat/projects/1/views/1?pane=issue&itemId=65645361

--- a/src/modules/plugins/chat.py
+++ b/src/modules/plugins/chat.py
@@ -288,31 +288,38 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
         user_id=message.author.id,
         role_ids=role_ids,
     )
+    channel_protected = policy_manager.is_protected(
+        guild_id=message.guild.id,
+        channel_id=message.channel.id,
+        user_id=message.author.id,
+        role_ids=role_ids,
+    )
 
     _guild_name = message.guild.name
     _channel_name = message.channel.name
     message_reference = None
 
-    if _guild_name != self.current_guild:
-        cprint("\n" + _guild_name.lower(), "purple", "_")
-        self.current_guild = _guild_name
+    if not channel_protected:
+        if _guild_name != self.current_guild:
+            cprint("\n" + _guild_name.lower(), "purple", "_")
+            self.current_guild = _guild_name
 
-    if _channel_name != self.current_channel:
-        cprint("#" + _channel_name, "green", end=" ")
-        print(f"({message.channel.id})")
-        self.current_channel = _channel_name
+        if _channel_name != self.current_channel:
+            cprint("#" + _channel_name, "green", end=" ")
+            print(f"({message.channel.id})")
+            self.current_channel = _channel_name
 
-    print(
-        "  {0}: {1}".format(
-            cstr(str=get_full_name(message), style=message.author.color),
-            CENSOR
-            and censor_message(
-                message.content.replace("\n", "\n\t"),
-                BANNED_WORDS,
+        print(
+            "  {0}: {1}".format(
+                cstr(str=get_full_name(message), style=message.author.color),
+                CENSOR
+                and censor_message(
+                    message.content.replace("\n", "\n\t"),
+                    BANNED_WORDS,
+                )
+                or message.content.replace("\n", "\n\t"),
             )
-            or message.content.replace("\n", "\n\t"),
         )
-    )
 
     memory_text = message.author.name + (
         f" (Nickname {_name})" if _name != message.author.name else ""
@@ -750,6 +757,15 @@ def chat(sona: AI_Manager):
 
         def set_channel_flag(self, channel_id, key, value):
             return policy_manager.set_channel_flag(channel_id, key, value)
+
+        def is_protected(self, guild_id, channel_id, user_id=None, role_ids=None, group_ids=None):
+            return policy_manager.is_protected(
+                guild_id,
+                channel_id,
+                user_id=user_id,
+                role_ids=role_ids,
+                group_ids=group_ids,
+            )
 
         def allow_command(self, channel_id, command):
             return policy_manager.allow_command(channel_id, command)

--- a/src/modules/plugins/chat.py
+++ b/src/modules/plugins/chat.py
@@ -299,31 +299,38 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
         user_id=message.author.id,
         role_ids=role_ids,
     )
+    channel_protected = policy_manager.is_protected(
+        guild_id=message.guild.id,
+        channel_id=message.channel.id,
+        user_id=message.author.id,
+        role_ids=role_ids,
+    )
 
     _guild_name = message.guild.name
     _channel_name = message.channel.name
     message_reference = None
 
-    if _guild_name != self.current_guild:
-        cprint("\n" + _guild_name.lower(), "purple", "_")
-        self.current_guild = _guild_name
+    if not channel_protected:
+        if _guild_name != self.current_guild:
+            cprint("\n" + _guild_name.lower(), "purple", "_")
+            self.current_guild = _guild_name
 
-    if _channel_name != self.current_channel:
-        cprint("#" + _channel_name, "green", end=" ")
-        print(f"({message.channel.id})")
-        self.current_channel = _channel_name
+        if _channel_name != self.current_channel:
+            cprint("#" + _channel_name, "green", end=" ")
+            print(f"({message.channel.id})")
+            self.current_channel = _channel_name
 
-    print(
-        "  {0}: {1}".format(
-            cstr(str=get_full_name(message), style=message.author.color),
-            CENSOR
-            and censor_message(
-                message.content.replace("\n", "\n\t"),
-                BANNED_WORDS,
+        print(
+            "  {0}: {1}".format(
+                cstr(str=get_full_name(message), style=message.author.color),
+                CENSOR
+                and censor_message(
+                    message.content.replace("\n", "\n\t"),
+                    BANNED_WORDS,
+                )
+                or message.content.replace("\n", "\n\t"),
             )
-            or message.content.replace("\n", "\n\t"),
         )
-    )
 
     memory_text = message.author.name + (
         f" (Nickname {_name})" if _name != message.author.name else ""
@@ -748,6 +755,15 @@ def chat(sona: AI_Manager):
 
         def set_channel_flag(self, channel_id, key, value):
             return policy_manager.set_channel_flag(channel_id, key, value)
+
+        def is_protected(self, guild_id, channel_id, user_id=None, role_ids=None, group_ids=None):
+            return policy_manager.is_protected(
+                guild_id,
+                channel_id,
+                user_id=user_id,
+                role_ids=role_ids,
+                group_ids=group_ids,
+            )
 
         def allow_command(self, channel_id, command):
             return policy_manager.allow_command(channel_id, command)

--- a/src/modules/plugins/chat.py
+++ b/src/modules/plugins/chat.py
@@ -302,8 +302,6 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
     channel_protected = policy_manager.is_protected(
         guild_id=message.guild.id,
         channel_id=message.channel.id,
-        user_id=message.author.id,
-        role_ids=role_ids,
     )
 
     _guild_name = message.guild.name

--- a/src/modules/plugins/term-commands.py
+++ b/src/modules/plugins/term-commands.py
@@ -12,6 +12,7 @@ from modules.channel_policies import (
     format_channel_policy,
     parse_channel_reference,
 )
+from modules.policy_admin import PolicyAdminError, get_or_create_policy_admin
 from modules.utils import (
     Colors,
     async_cprint as cprint,
@@ -457,21 +458,24 @@ async def set_pinned_channel(mem):
     """Set the current channel"""
     await set_channel(mem, ret=False)
 
-# TODO: Use the prompt/edit prompt system for all these commands instead of raw input, but also allow for args to passed in all at once if i know the options
-@MANAGER.term("channels")
-async def manage_channel_policies(mem, bot, manager):
-    """Manage channel policy overrides and blacklist settings"""
+@MANAGER.term("policy")
+async def manage_policies(mem, bot, manager):
+    """Manage policy rules across namespaces and scopes"""
     usage = (
-        "channels list\n"
-        "channels show <channel_id|<#channel_id>|here>\n"
-        "channels set <channel> <can_speak|respond_all> <true|false>\n"
-        "channels allow <channel> <command>\n"
-        "channels deny <channel> <command>\n"
-        "channels blacklist <add|remove> <channel>\n"
-        "channels remove <channel>"
+        "policy namespaces\n"
+        "policy show <namespace> <scope> <target>\n"
+        "policy set <namespace> <scope> <target> <action> <allow|deny>\n"
+        "policy remove <namespace> <scope> <target> <action>\n"
+        "policy clear <namespace> <scope> <target>\n"
+        "policy groups list <namespace>\n"
+        "policy groups show <namespace> <group>\n"
+        "policy groups upsert <namespace> <group> [members_csv|-] [roles_csv|-]\n"
+        "policy groups remove <namespace> <group>\n"
+        "policy groups member <add|remove> <namespace> <group> <user_id>\n"
+        "policy groups role <add|remove> <namespace> <group> <role_id>"
     )
 
-    raw = await prompt("Enter channels command: ")
+    raw = await prompt("Enter policy command: ")
     parts = [p for p in raw.strip().split(" ") if p] if raw else []
     if not parts:
         cprint(usage, "yellow")
@@ -479,114 +483,126 @@ async def manage_channel_policies(mem, bot, manager):
 
     action = parts[0].lower()
     args = parts[1:]
-    chat = manager.chat
+    admin = get_or_create_policy_admin(manager)
 
     if action in {"help", "h"}:
         cprint(usage, "yellow")
         return
 
-    if action == "list":
-        channel_map = chat.policy_manager.get_channels()
-        if not channel_map:
-            cprint("No channel overrides are configured.", "yellow")
+    try:
+        result = await _handle_term_policy(mem, bot, admin, action, args, usage)
+        if result is not None:
+            cprint(result, "yellow")
             return
-        lines = [
-            format_channel_policy(channel_id, channel_map[channel_id])
-            for channel_id in sorted(channel_map.keys())
-        ]
-        cprint("\n".join(lines[:50]), "yellow")
-        return
-
-    if action == "show":
-        if len(args) < 1:
-            cprint(usage, "yellow")
-            return
-        channel, error = await resolve_term_text_channel(mem, bot, args[0])
-        if error:
-            cprint(error, "red")
-            return
-        cprint(format_channel_policy(channel.id, chat.policy_manager.get_channel_policy(channel.id)), "yellow")
-        return
-
-    if action == "remove":
-        if len(args) < 1:
-            cprint(usage, "yellow")
-            return
-        channel, error = await resolve_term_text_channel(mem, bot, args[0])
-        if error:
-            cprint(error, "red")
-            return
-        removed = chat.policy_manager.remove_channel_policy(channel.id)
-        if removed is None:
-            cprint(f"No override existed for `{channel.id}`.", "yellow")
-            return
-        cprint(f"Removed override for `{channel.id}`.", "yellow")
-        return
-
-    if action == "blacklist":
-        if len(args) < 2:
-            cprint(usage, "yellow")
-            return
-        sub_action = args[0].lower()
-        channel, error = await resolve_term_text_channel(mem, bot, args[1])
-        if error:
-            cprint(error, "red")
-            return
-        if sub_action == "add":
-            policy = chat.policy_manager.blacklist_add(channel.id)
-            cprint(
-                f"Blacklisted `{channel.id}`\n{format_channel_policy(channel.id, policy)}",
-                "yellow",
-            )
-            return
-        if sub_action == "remove":
-            policy = chat.policy_manager.blacklist_remove(channel.id)
-            cprint(
-                f"Un-blacklisted `{channel.id}`\n{format_channel_policy(channel.id, policy)}",
-                "yellow",
-            )
-            return
-        cprint(usage, "yellow")
-        return
-
-    if action in {"set", "allow", "deny"}:
-        if len(args) < 2:
-            cprint(usage, "yellow")
-            return
-        channel, error = await resolve_term_text_channel(mem, bot, args[0])
-        if error:
-            cprint(error, "red")
-            return
-
-        if action == "set":
-            if len(args) < 3:
-                cprint(usage, "yellow")
-                return
-            field = args[1].lower().strip()
-            if field not in {"can_speak", "respond_all"}:
-                cprint("Field must be can_speak or respond_all.", "red")
-                return
-            try:
-                value = parse_bool(args[2])
-            except ValueError:
-                cprint("Value must be true/false.", "red")
-                return
-            policy = chat.policy_manager.set_channel_flag(channel.id, field, value)
-            cprint(format_channel_policy(channel.id, policy), "yellow")
-            return
-
-        command_name = args[1].lower().strip().lstrip("$")
-        if not command_name:
-            cprint("Command cannot be empty.", "red")
-            return
-        if action == "allow":
-            policy = chat.policy_manager.allow_command(channel.id, command_name)
-        else:
-            policy = chat.policy_manager.deny_command(channel.id, command_name)
-        cprint(format_channel_policy(channel.id, policy), "yellow")
+    except PolicyAdminError as e:
+        cprint(str(e), "red")
         return
 
     cprint(usage, "yellow")
+
+
+async def _handle_term_policy(mem, bot, admin, action, args, usage):
+    if action == "namespaces":
+        ns_list = admin.list_namespaces()
+        return "Namespaces: " + ", ".join(ns_list)
+
+    if action == "show":
+        if len(args) < 3:
+            return usage
+        namespace, scope, raw_target = args[0], args[1], args[2]
+        target = await _resolve_term_target(mem, bot, scope, raw_target)
+        return admin.show_rules(namespace, scope, target)
+
+    if action == "set":
+        if len(args) < 5:
+            return usage
+        namespace, scope, raw_target, act, effect = args[0], args[1], args[2], args[3], args[4]
+        target = await _resolve_term_target(mem, bot, scope, raw_target)
+        return admin.set_rule(namespace, scope, target, act, effect)
+
+    if action == "remove":
+        if len(args) < 4:
+            return usage
+        namespace, scope, raw_target, act = args[0], args[1], args[2], args[3]
+        target = await _resolve_term_target(mem, bot, scope, raw_target)
+        return admin.remove_rule(namespace, scope, target, act)
+
+    if action == "clear":
+        if len(args) < 3:
+            return usage
+        namespace, scope, raw_target = args[0], args[1], args[2]
+        target = await _resolve_term_target(mem, bot, scope, raw_target)
+        return admin.clear_scope(namespace, scope, target)
+
+    if action == "groups":
+        return _handle_term_policy_groups(admin, args, usage)
+
+    return None
+
+
+def _handle_term_policy_groups(admin, args, usage):
+    if len(args) < 2:
+        return usage
+    sub = args[0].lower()
+
+    if sub == "list":
+        return admin.list_groups(args[1])
+
+    if sub == "show":
+        if len(args) < 3:
+            return usage
+        return admin.show_group(args[1], args[2])
+
+    if sub == "upsert":
+        if len(args) < 3:
+            return usage
+        namespace, group = args[1], args[2]
+        members = args[3] if len(args) > 3 else None
+        roles = args[4] if len(args) > 4 else None
+        return admin.upsert_group(namespace, group, members=members, role_ids=roles)
+
+    if sub == "remove":
+        if len(args) < 3:
+            return usage
+        return admin.remove_group(args[1], args[2])
+
+    if sub == "member":
+        if len(args) < 5:
+            return usage
+        op, namespace, group, user_id = args[1], args[2], args[3], args[4]
+        if op == "add":
+            return admin.add_group_member(namespace, group, user_id)
+        if op == "remove":
+            return admin.remove_group_member(namespace, group, user_id)
+        return usage
+
+    if sub == "role":
+        if len(args) < 5:
+            return usage
+        op, namespace, group, role_id = args[1], args[2], args[3], args[4]
+        if op == "add":
+            return admin.add_group_role(namespace, group, role_id)
+        if op == "remove":
+            return admin.remove_group_role(namespace, group, role_id)
+        return usage
+
+    return usage
+
+
+async def _resolve_term_target(mem, bot, scope, raw_target):
+    """Resolve terminal-specific target references like 'here' for channels."""
+    scope_lower = scope.lower()
+    if raw_target.lower() in {"here", "current", "this"} and scope_lower == "channel":
+        channel, error = await resolve_term_text_channel(mem, bot, "here")
+        if error:
+            raise PolicyAdminError(error)
+        return str(channel.id)
+    # Channel reference (numeric or <#id>)
+    if scope_lower == "channel":
+        channel_id = parse_channel_reference(raw_target)
+        if channel_id is not None:
+            return str(channel_id)
+    return raw_target
 
 
 @MANAGER.term

--- a/src/modules/plugins/term-commands.py
+++ b/src/modules/plugins/term-commands.py
@@ -130,6 +130,12 @@ async def intercept_reply(response: str, Data_Manager: AI_Manager) -> str:
     return r
 
 
+def _is_channel_protected(manager, channel):
+    guild = getattr(channel, "guild", None)
+    guild_id = getattr(guild, "id", None)
+    return manager.chat.is_protected(guild_id, channel.id)
+
+
 @MANAGER.effect("chat", "set", prepend=False)
 def save_recent_message(_, chat_id, message_type, author, message, replying_to=None):
     """Save the recent message details to the terminal commands manager"""
@@ -1064,7 +1070,11 @@ async def god_cmd(mem, bot):
 @MANAGER.term("sum")
 async def summarize_chat(mem, bot):
     """Summarize the chat history in the current channel"""
-    id = get_channel(mem, bot).id
+    channel = get_channel(mem, bot)
+    if _is_channel_protected(MANAGER.MANAGER, channel):
+        cprint("Access denied: channel history is protected.", "red")
+        return
+    id = channel.id
 
     summary, D = MANAGER.MANAGER.chat.summarize(id)
 
@@ -1093,6 +1103,9 @@ async def summarize_chat(mem, bot):
 async def print_channel_history(mem, bot, manager):
     """Print the chat history in the current channel"""
     c = get_channel(mem, bot)
+    if _is_channel_protected(manager, c):
+        cprint("Access denied: channel history is protected.", "red")
+        return
     messages = manager.chat.get_chat(c.id)
     cprint("Channel chat history:", "yellow")
     messages = [f"{m[1]}: {m[2]}" for m in messages]
@@ -1109,6 +1122,9 @@ async def save_chat():
 async def run_self_cmd(mem, bot, manager):
     """Run a self-command with arguments in the current channel"""
     c = get_channel(mem, bot)
+    if _is_channel_protected(manager, c):
+        cprint("Access denied: channel history is protected.", "red")
+        return
     history = manager.chat.get_history(c.id)
     # ai = client.config.get("AI")
     config = manager.config.copy()

--- a/src/modules/plugins/term-commands.py
+++ b/src/modules/plugins/term-commands.py
@@ -452,6 +452,12 @@ async def intercept_reply(response: str, Data_Manager: AI_Manager) -> str:
     return r
 
 
+def _is_channel_protected(manager, channel):
+    guild = getattr(channel, "guild", None)
+    guild_id = getattr(guild, "id", None)
+    return manager.chat.is_protected(guild_id, channel.id)
+
+
 @MANAGER.effect("chat", "set", prepend=False)
 def save_recent_message(_, chat_id, message_type, author, message, replying_to=None):
     """Save the recent message details to the terminal commands manager"""
@@ -1410,7 +1416,11 @@ async def god_cmd(mem, bot):
 @MANAGER.term("sum")
 async def summarize_chat(mem, bot):
     """Summarize the chat history in the current channel"""
-    id = get_channel(mem, bot).id
+    channel = get_channel(mem, bot)
+    if _is_channel_protected(MANAGER.MANAGER, channel):
+        cprint("Access denied: channel history is protected.", "red")
+        return
+    id = channel.id
 
     summary, D = MANAGER.MANAGER.chat.summarize(id)
 
@@ -1439,6 +1449,9 @@ async def summarize_chat(mem, bot):
 async def print_channel_history(mem, bot, manager):
     """Print the chat history in the current channel"""
     c = get_channel(mem, bot)
+    if _is_channel_protected(manager, c):
+        cprint("Access denied: channel history is protected.", "red")
+        return
     messages = manager.chat.get_chat(c.id)
     cprint("Channel chat history:", "yellow")
     messages = [f"{m[1]}: {m[2]}" for m in messages]
@@ -1455,6 +1468,9 @@ async def save_chat():
 async def run_self_cmd(mem, bot, manager):
     """Run a self-command with arguments in the current channel"""
     c = get_channel(mem, bot)
+    if _is_channel_protected(manager, c):
+        cprint("Access denied: channel history is protected.", "red")
+        return
     history = manager.chat.get_history(c.id)
     # ai = client.config.get("AI")
     config = manager.config.copy()

--- a/src/modules/policy_admin.py
+++ b/src/modules/policy_admin.py
@@ -216,6 +216,7 @@ class PolicyAdmin:
     def _persist(self, namespace):
         # Chat namespace uses ChannelPolicies persistence (legacy path)
         if namespace == "chat" and hasattr(self.sonata, "chat"):
+            self.sonata.chat.policy_manager.refresh_from_policy_api()
             self.sonata.chat.policy_manager._persist()
             return
         # Generic namespace persistence

--- a/src/modules/policy_admin.py
+++ b/src/modules/policy_admin.py
@@ -1,0 +1,341 @@
+"""
+Shared policy admin service layer for ``$policy`` (Discord) and ``policy`` (terminal).
+
+Centralizes namespace validation, scope/target normalization, action and effect
+validation, formatting of rule and group output, and persistence hooks. Command
+entrypoints resolve Discord or terminal-specific references at the edge, then
+delegate to this service.
+"""
+
+from modules.policy_api import (
+    EFFECT_ALLOW,
+    EFFECT_DENY,
+    SCOPES,
+    get_or_create_policy_api,
+)
+
+
+class PolicyAdminError(Exception):
+    """Raised when a policy admin operation fails validation."""
+
+
+class PolicyAdmin:
+    """Shared service used by both Discord and terminal policy command surfaces."""
+
+    def __init__(self, sonata):
+        self.sonata = sonata
+        self.api = get_or_create_policy_api(sonata)
+
+    # ── Namespace helpers ────────────────────────────────────────────────
+
+    def list_namespaces(self):
+        return self.api.list_namespaces()
+
+    def require_namespace(self, namespace):
+        ns = namespace.strip().lower()
+        if not self.api.has_namespace(ns):
+            raise PolicyAdminError(f"Unknown namespace `{ns}`.")
+        return ns
+
+    # ── Validation ───────────────────────────────────────────────────────
+
+    def validate_scope(self, scope):
+        s = scope.strip().lower()
+        if s not in SCOPES:
+            raise PolicyAdminError(
+                f"Invalid scope `{scope}`. Must be one of: {', '.join(SCOPES)}."
+            )
+        return s
+
+    def validate_effect(self, effect):
+        e = effect.strip().lower()
+        if e not in {EFFECT_ALLOW, EFFECT_DENY}:
+            raise PolicyAdminError(f"Effect must be `allow` or `deny`, got `{effect}`.")
+        return e
+
+    def validate_action(self, namespace, action):
+        a = action.strip().lower()
+        if not a:
+            raise PolicyAdminError("Action cannot be empty.")
+        expected_prefix = f"{namespace}."
+        if not a.startswith(expected_prefix):
+            raise PolicyAdminError(
+                f"Action `{a}` must start with namespace prefix `{expected_prefix}`."
+            )
+        return a
+
+    def normalize_target(self, target):
+        t = str(target).strip()
+        if not t:
+            raise PolicyAdminError("Target cannot be empty.")
+        return t
+
+    # ── Read operations ──────────────────────────────────────────────────
+
+    def show_rules(self, namespace, scope, target):
+        ns = self.require_namespace(namespace)
+        sc = self.validate_scope(scope)
+        t = self.normalize_target(target)
+        rules = self.api.get_scope_rules(ns, sc, t)
+        if not rules:
+            return f"No rules for `{ns}` {sc} `{t}`."
+        lines = [f"Rules for `{ns}` {sc} `{t}`:"]
+        for rule in sorted(rules, key=lambda r: r.action):
+            lines.append(f"  {rule.action} → {rule.effect}")
+        return "\n".join(lines)
+
+    def list_groups(self, namespace):
+        ns = self.require_namespace(namespace)
+        groups = self.api.list_groups(ns)
+        if not groups:
+            return f"No groups in namespace `{ns}`."
+        lines = [f"Groups in `{ns}`:"]
+        for group_id in groups:
+            lines.append(f"  {group_id}")
+        return "\n".join(lines)
+
+    def show_group(self, namespace, group_name):
+        ns = self.require_namespace(namespace)
+        group = self.api.get_group(ns, group_name)
+        if group is None:
+            raise PolicyAdminError(f"Group `{group_name}` not found in `{ns}`.")
+        group_id = group["id"]
+        members = group["members"]
+        roles = group["roles"]
+        rules = self.api.get_scope_rules(ns, "group", group_id)
+
+        lines = [f"Group `{group_id}`:"]
+        lines.append(f"  Members: {', '.join(members) if members else '(none)'}")
+        lines.append(f"  Roles: {', '.join(roles) if roles else '(none)'}")
+        if rules:
+            lines.append("  Rules:")
+            for rule in sorted(rules, key=lambda r: r.action):
+                lines.append(f"    {rule.action} → {rule.effect}")
+        else:
+            lines.append("  Rules: (none)")
+        return "\n".join(lines)
+
+    # ── Write operations ─────────────────────────────────────────────────
+
+    def set_rule(self, namespace, scope, target, action, effect):
+        ns = self.require_namespace(namespace)
+        sc = self.validate_scope(scope)
+        t = self.normalize_target(target)
+        a = self.validate_action(ns, action)
+        e = self.validate_effect(effect)
+        rule = self.api.set_rule(ns, sc, t, a, e)
+        self._persist(ns)
+        return f"Set `{a}` → `{e}` on {sc} `{t}` in `{ns}`."
+
+    def remove_rule(self, namespace, scope, target, action):
+        ns = self.require_namespace(namespace)
+        sc = self.validate_scope(scope)
+        t = self.normalize_target(target)
+        a = self.validate_action(ns, action)
+        removed = self.api.remove_rule(ns, sc, t, a)
+        if not removed:
+            raise PolicyAdminError(
+                f"No rule `{a}` on {sc} `{t}` in `{ns}` to remove."
+            )
+        self._persist(ns)
+        return f"Removed `{a}` from {sc} `{t}` in `{ns}`."
+
+    def clear_scope(self, namespace, scope, target):
+        ns = self.require_namespace(namespace)
+        sc = self.validate_scope(scope)
+        t = self.normalize_target(target)
+        self.api.clear_scope(ns, sc, t)
+        self._persist(ns)
+        return f"Cleared all rules for {sc} `{t}` in `{ns}`."
+
+    # ── Group write operations ───────────────────────────────────────────
+
+    def upsert_group(self, namespace, group_name, *, members=None, role_ids=None):
+        ns = self.require_namespace(namespace)
+        name = group_name.strip().lower()
+        if not name:
+            raise PolicyAdminError("Group name cannot be empty.")
+        member_list = _parse_csv(members) if isinstance(members, str) else members
+        role_list = _parse_csv(role_ids) if isinstance(role_ids, str) else role_ids
+        group_id = self.api.upsert_group(
+            ns, name, members=member_list, role_ids=role_list
+        )
+        self._persist(ns)
+        return f"Upserted group `{group_id}`."
+
+    def remove_group(self, namespace, group_name):
+        ns = self.require_namespace(namespace)
+        removed = self.api.remove_group(ns, group_name)
+        if not removed:
+            raise PolicyAdminError(f"Group `{group_name}` not found in `{ns}`.")
+        self._persist(ns)
+        return f"Removed group `{group_name}` from `{ns}`."
+
+    def add_group_member(self, namespace, group_name, user_id):
+        ns = self.require_namespace(namespace)
+        self.api.add_group_member(ns, group_name, user_id)
+        self._persist(ns)
+        return f"Added `{user_id}` to group `{group_name}` in `{ns}`."
+
+    def remove_group_member(self, namespace, group_name, user_id):
+        ns = self.require_namespace(namespace)
+        removed = self.api.remove_group_member(ns, group_name, user_id)
+        if not removed:
+            raise PolicyAdminError(
+                f"User `{user_id}` not in group `{group_name}` in `{ns}`."
+            )
+        self._persist(ns)
+        return f"Removed `{user_id}` from group `{group_name}` in `{ns}`."
+
+    def add_group_role(self, namespace, group_name, role_id):
+        ns = self.require_namespace(namespace)
+        self.api.bind_group_role(ns, group_name, role_id)
+        self._persist(ns)
+        return f"Bound role `{role_id}` to group `{group_name}` in `{ns}`."
+
+    def remove_group_role(self, namespace, group_name, role_id):
+        ns = self.require_namespace(namespace)
+        removed = self.api.unbind_group_role(ns, group_name, role_id)
+        if not removed:
+            raise PolicyAdminError(
+                f"Role `{role_id}` not bound to group `{group_name}` in `{ns}`."
+            )
+        self._persist(ns)
+        return f"Unbound role `{role_id}` from group `{group_name}` in `{ns}`."
+
+    def set_group_rule(self, namespace, group_name, action, effect):
+        ns = self.require_namespace(namespace)
+        a = self.validate_action(ns, action)
+        e = self.validate_effect(effect)
+        self.api.set_group_rule(ns, group_name, a, e)
+        self._persist(ns)
+        return f"Set `{a}` → `{e}` on group `{group_name}` in `{ns}`."
+
+    # ── Persistence ──────────────────────────────────────────────────────
+
+    def _persist(self, namespace):
+        # Chat namespace uses ChannelPolicies persistence (legacy path)
+        if namespace == "chat" and hasattr(self.sonata, "chat"):
+            self.sonata.chat.policy_manager._persist()
+            return
+        # Generic namespace persistence
+        self._persist_namespace(namespace)
+
+    def _persist_namespace(self, namespace):
+        data = self._serialize_namespace(namespace)
+        all_ns = self.sonata.config.get("policy_namespaces", {})
+        all_ns[namespace] = data
+        self.sonata.config.set(policy_namespaces=all_ns)
+        if self.sonata.has("beacon"):
+            branch = self.sonata.beacon.branch("policies").branch("namespaces")
+            branch.illuminate(namespace, data)
+
+    def _serialize_namespace(self, namespace):
+        ns_rules = self.api._rules.get(namespace, {})
+        serialized = {"rules": {}, "groups": {}}
+
+        for scope in SCOPES:
+            scope_map = ns_rules.get(scope, {})
+            if scope == "group":
+                continue
+            for scope_id, rules in scope_map.items():
+                for rule in rules:
+                    key = f"{scope}:{scope_id}"
+                    entry = serialized["rules"].setdefault(key, [])
+                    entry.append({"action": rule.action, "effect": rule.effect})
+
+        for group_id in self.api.list_groups(namespace):
+            name = group_id.split(":", 1)[1] if ":" in group_id else group_id
+            group_data = self.api.get_group(namespace, name)
+            group_rules = self.api.get_scope_rules(namespace, "group", group_id)
+            serialized["groups"][group_id] = {
+                "members": group_data.get("members", []) if group_data else [],
+                "roles": group_data.get("roles", []) if group_data else [],
+                "rules": [
+                    {"action": r.action, "effect": r.effect} for r in group_rules
+                ],
+            }
+
+        return serialized
+
+    def load_namespace(self, namespace):
+        """Load persisted generic namespace state into PolicyAPI."""
+        data = None
+        if self.sonata.has("beacon"):
+            branch = self.sonata.beacon.branch("policies").branch("namespaces")
+            data = branch.discover(namespace)
+
+        config_ns = self.sonata.config.get("policy_namespaces", {})
+        config_data = config_ns.get(namespace)
+        if config_data is not None:
+            data = config_data
+
+        if data is None:
+            return
+
+        for key, rules in (data.get("rules") or {}).items():
+            parts = key.split(":", 1)
+            if len(parts) != 2:
+                continue
+            scope, scope_id = parts
+            for rule in rules:
+                action = rule.get("action", "")
+                effect = rule.get("effect", "")
+                if action and effect:
+                    try:
+                        self.api.set_rule(namespace, scope, scope_id, action, effect)
+                    except (ValueError, KeyError):
+                        pass
+
+        for group_id, group_data in (data.get("groups") or {}).items():
+            name = group_id.split(":", 1)[1] if ":" in group_id else group_id
+            self.api.upsert_group(
+                namespace,
+                name,
+                members=group_data.get("members", []),
+                role_ids=group_data.get("roles", []),
+            )
+            for rule in group_data.get("rules", []):
+                action = rule.get("action", "")
+                effect = rule.get("effect", "")
+                if action and effect:
+                    try:
+                        self.api.set_group_rule(namespace, name, action, effect)
+                    except (ValueError, KeyError):
+                        pass
+
+    def load_all_namespaces(self):
+        """Load all persisted generic namespace state on startup."""
+        config_ns = self.sonata.config.get("policy_namespaces", {})
+        loaded = set()
+
+        for ns_name in config_ns:
+            if self.api.has_namespace(ns_name):
+                self.load_namespace(ns_name)
+                loaded.add(ns_name)
+
+        if self.sonata.has("beacon"):
+            branch = self.sonata.beacon.branch("policies").branch("namespaces")
+            # Beacon discover at folder level returns dict of subfolders
+            try:
+                all_data = branch.discover("") or {}
+            except Exception:
+                all_data = {}
+            for ns_name in all_data:
+                if ns_name not in loaded and self.api.has_namespace(ns_name):
+                    self.load_namespace(ns_name)
+
+
+def _parse_csv(value):
+    if value is None or value == "-":
+        return None
+    return [v.strip() for v in str(value).split(",") if v.strip()]
+
+
+def get_or_create_policy_admin(sonata):
+    admin = getattr(sonata, "_policy_admin", None)
+    if isinstance(admin, PolicyAdmin):
+        return admin
+    admin = PolicyAdmin(sonata)
+    setattr(sonata, "_policy_admin", admin)
+    return admin

--- a/src/modules/policy_admin.py
+++ b/src/modules/policy_admin.py
@@ -149,6 +149,10 @@ class PolicyAdmin:
         t = self.canonicalize_target(ns, sc, target)
         a = self.validate_action(ns, action)
         e = self.validate_effect(effect)
+        if a == "chat.protected" and sc != "channel":
+            raise PolicyAdminError(
+                "`chat.protected` is channel-scoped only (Beacon encryption is per channel)."
+            )
         rule = self.api.set_rule(ns, sc, t, a, e)
         self._persist(ns)
         return f"Set `{a}` → `{e}` on {sc} `{t}` in `{ns}`."

--- a/tests/test_beacon_policy.py
+++ b/tests/test_beacon_policy.py
@@ -191,6 +191,28 @@ class BeaconPolicyTests(unittest.TestCase):
             )
         )
 
+    def test_chat_channel_path_rule_encrypts_saved_history(self):
+        action = self.beacon._path_action(f"{self.beacon.home}/chat/value/i123")
+        self.beacon.policy_api.set_rule(
+            "beacon",
+            "guild",
+            self.beacon_module.GLOBAL_POLICY_SCOPE_ID,
+            action,
+            "allow",
+        )
+
+        payload = {123: [("User", "alice", "hello", None)]}
+        self.beacon.branch("chat").illuminate("value", payload, encrypted=False)
+
+        with open(f"{self.beacon.home}/chat/value/i123.p", "rb") as handle:
+            raw_encrypted = handle.read()
+
+        with self.assertRaises(Exception):
+            pickle.loads(raw_encrypted)
+
+        loaded = self.beacon.branch("chat").discover("value", encrypted=False)
+        self.assertEqual(loaded, payload)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_channel_policies.py
+++ b/tests/test_channel_policies.py
@@ -84,6 +84,7 @@ class ChannelPolicyTests(unittest.TestCase):
         policy = ChannelPolicy.default()
         self.assertTrue(policy.can_speak)
         self.assertFalse(policy.respond_all)
+        self.assertFalse(policy.protected)
         self.assertEqual(policy.command_policy_mode, DENYLIST)
         self.assertEqual(policy.commands, [])
         self.assertTrue(policy.allows_command("help"))
@@ -148,6 +149,11 @@ class ChannelPolicyTests(unittest.TestCase):
             sonata._beacon_store[("policies", "channels")]["123"]["command_policy_mode"],
             DENYLIST,
         )
+
+    def test_policy_round_trip_preserves_protected_flag(self):
+        policy = ChannelPolicy.normalize({"protected": True, "commands": ["help"]})
+        self.assertTrue(policy.protected)
+        self.assertTrue(ChannelPolicy.normalize(policy.to_dict()).protected)
 
     def test_missing_permissions_are_denied(self):
         class Permissions:

--- a/tests/test_channel_policies.py
+++ b/tests/test_channel_policies.py
@@ -87,6 +87,7 @@ class ChannelPolicyTests(unittest.TestCase):
         policy = ChannelPolicy.default()
         self.assertTrue(policy.can_speak)
         self.assertFalse(policy.respond_all)
+        self.assertFalse(policy.protected)
         self.assertEqual(policy.command_policy_mode, DENYLIST)
         self.assertEqual(policy.commands, [])
         self.assertTrue(policy.allows_command("help"))
@@ -151,6 +152,11 @@ class ChannelPolicyTests(unittest.TestCase):
             sonata._beacon_store[("policies", "channels")]["123"]["command_policy_mode"],
             DENYLIST,
         )
+
+    def test_policy_round_trip_preserves_protected_flag(self):
+        policy = ChannelPolicy.normalize({"protected": True, "commands": ["help"]})
+        self.assertTrue(policy.protected)
+        self.assertTrue(ChannelPolicy.normalize(policy.to_dict()).protected)
 
     def test_missing_permissions_are_denied(self):
         class Permissions:

--- a/tests/test_policy_api.py
+++ b/tests/test_policy_api.py
@@ -62,6 +62,9 @@ class FakeSonata:
         self._beacon_store = {}
         self.beacon = FakeBranch(self._beacon_store)
 
+    def has(self, name):
+        return hasattr(self, name)
+
 
 class PolicyApiTests(unittest.TestCase):
     def test_duplicate_namespace_registration_is_rejected(self):
@@ -402,6 +405,75 @@ class PolicyApiTests(unittest.TestCase):
         )
         self.assertFalse(
             policies.should_respond_all(guild_id=2, channel_id=10, user_id=1)
+        )
+
+    def test_protected_channel_sets_chat_and_beacon_rules(self):
+        sonata = FakeSonata()
+        sonata.beacon.home = "Beacon/Home"
+        policies = ChannelPolicies(sonata)
+
+        policies.set_channel_flag(321, "protected", True)
+
+        self.assertTrue(
+            policies.is_protected(guild_id=1, channel_id=321, user_id=7)
+        )
+        self.assertTrue(
+            policies.policy_api.evaluate(
+                "beacon",
+                "beacon.encrypt.path.beacon/home/chat/value/i321",
+                guild_id="__global__",
+                default=False,
+            )
+        )
+
+    def test_unprotect_channel_removes_beacon_rule(self):
+        sonata = FakeSonata()
+        sonata.beacon.home = "Beacon/Home"
+        policies = ChannelPolicies(sonata)
+
+        policies.set_channel_flag(321, "protected", True)
+        policies.set_channel_flag(321, "protected", False)
+
+        self.assertFalse(
+            policies.is_protected(guild_id=1, channel_id=321, user_id=7)
+        )
+        self.assertFalse(
+            policies.policy_api.evaluate(
+                "beacon",
+                "beacon.encrypt.path.beacon/home/chat/value/i321",
+                guild_id="__global__",
+                default=False,
+            )
+        )
+
+    def test_refresh_from_policy_api_bridges_unified_chat_rules(self):
+        sonata = FakeSonata()
+        sonata.beacon.home = "Beacon/Home"
+        policies = ChannelPolicies(sonata)
+
+        policies.policy_api.set_rule(
+            "chat", "channel", 444, "chat.protected", "allow"
+        )
+        policies.policy_api.set_rule(
+            "chat", "channel", 444, "chat.command.*", "deny"
+        )
+        policies.policy_api.set_rule(
+            "chat", "channel", 444, "chat.command.help", "allow"
+        )
+
+        policies.refresh_from_policy_api()
+
+        channel_policy = policies.get_channel_policy(444)
+        self.assertTrue(channel_policy.protected)
+        self.assertEqual(channel_policy.command_policy_mode, ALLOWLIST)
+        self.assertEqual(channel_policy.commands, ["help"])
+        self.assertTrue(
+            policies.policy_api.evaluate(
+                "beacon",
+                "beacon.encrypt.path.beacon/home/chat/value/i444",
+                guild_id="__global__",
+                default=False,
+            )
         )
 
 

--- a/tests/test_policy_api.py
+++ b/tests/test_policy_api.py
@@ -413,12 +413,52 @@ class PolicyApiTests(unittest.TestCase):
             policies.should_respond_all(guild_id=2, channel_id=10, user_id=1)
         )
 
+    def test_protected_channel_sets_chat_and_beacon_rules(self):
+        sonata = FakeSonata()
+        sonata.beacon.home = "Beacon/Home"
+        policies = ChannelPolicies(sonata)
+
+        policies.set_channel_flag(321, "protected", True)
+
+        self.assertTrue(
+            policies.is_protected(guild_id=1, channel_id=321, user_id=7)
+        )
+        self.assertTrue(
+            policies.policy_api.evaluate(
+                "beacon",
+                "beacon.encrypt.path.beacon/home/chat/value/i321",
+                guild_id="__global__",
+                default=False,
+            )
+        )
+
+    def test_unprotect_channel_removes_beacon_rule(self):
+        sonata = FakeSonata()
+        sonata.beacon.home = "Beacon/Home"
+        policies = ChannelPolicies(sonata)
+
+        policies.set_channel_flag(321, "protected", True)
+        policies.set_channel_flag(321, "protected", False)
+
+        self.assertFalse(
+            policies.is_protected(guild_id=1, channel_id=321, user_id=7)
+        )
+        self.assertFalse(
+            policies.policy_api.evaluate(
+                "beacon",
+                "beacon.encrypt.path.beacon/home/chat/value/i321",
+                guild_id="__global__",
+                default=False,
+            )
+        )
+
     def test_refresh_from_policy_api_bridges_unified_chat_rules(self):
         sonata = FakeSonata()
+        sonata.beacon.home = "Beacon/Home"
         policies = ChannelPolicies(sonata)
 
         policies.policy_api.set_rule(
-            "chat", "channel", 444, "chat.can_speak", "deny"
+            "chat", "channel", 444, "chat.protected", "allow"
         )
         policies.policy_api.set_rule(
             "chat", "channel", 444, "chat.command.*", "deny"
@@ -430,9 +470,17 @@ class PolicyApiTests(unittest.TestCase):
         policies.refresh_from_policy_api()
 
         channel_policy = policies.get_channel_policy(444)
-        self.assertFalse(channel_policy.can_speak)
+        self.assertTrue(channel_policy.protected)
         self.assertEqual(channel_policy.command_policy_mode, ALLOWLIST)
         self.assertEqual(channel_policy.commands, ["help"])
+        self.assertTrue(
+            policies.policy_api.evaluate(
+                "beacon",
+                "beacon.encrypt.path.beacon/home/chat/value/i444",
+                guild_id="__global__",
+                default=False,
+            )
+        )
 
     def test_refresh_from_policy_api_preserves_custom_chat_rules(self):
         sonata = FakeSonata()
@@ -532,6 +580,31 @@ class PolicyApiTests(unittest.TestCase):
         self.assertFalse(reloaded.can_speak(guild_id=1, channel_id=555, user_id=7))
         self.assertTrue(
             reloaded.should_respond_all(guild_id=1, channel_id=555, user_id=7)
+        )
+
+    def test_refresh_from_policy_api_preserves_custom_chat_rules(self):
+        sonata = FakeSonata()
+        policies = ChannelPolicies(sonata)
+
+        policies.policy_api.set_rule(
+            "chat", "channel", 777, "chat.feature.custom", "allow"
+        )
+        policies.policy_api.set_rule(
+            "chat", "channel", 777, "chat.can_speak", "deny"
+        )
+
+        policies.refresh_from_policy_api()
+
+        rules = {
+            (rule.action, rule.effect)
+            for rule in policies.policy_api.get_scope_rules("chat", "channel", 777)
+        }
+        self.assertIn(("chat.feature.custom", "allow"), rules)
+        self.assertIn(("chat.can_speak", "deny"), rules)
+        channel_policy = policies.get_channel_policy(777)
+        self.assertEqual(
+            channel_policy.extra_rules,
+            [{"action": "chat.feature.custom", "effect": "allow"}],
         )
 
 

--- a/tests/test_policy_api.py
+++ b/tests/test_policy_api.py
@@ -582,29 +582,55 @@ class PolicyApiTests(unittest.TestCase):
             reloaded.should_respond_all(guild_id=1, channel_id=555, user_id=7)
         )
 
-    def test_refresh_from_policy_api_preserves_custom_chat_rules(self):
+    def test_extra_rules_reject_reserved_chat_actions(self):
+        policy = ChannelPolicy.normalize(
+            {
+                "protected": False,
+                "extra_rules": [
+                    {"action": "chat.protected", "effect": "allow"},
+                    {"action": "chat.feature.custom", "effect": "deny"},
+                ],
+            }
+        )
+        self.assertFalse(policy.protected)
+        self.assertEqual(
+            policy.extra_rules,
+            [{"action": "chat.feature.custom", "effect": "deny"}],
+        )
+
+    def test_is_protected_is_channel_scoped_only(self):
         sonata = FakeSonata()
         policies = ChannelPolicies(sonata)
-
+        policies.set_channel_flag(321, "protected", True)
         policies.policy_api.set_rule(
-            "chat", "channel", 777, "chat.feature.custom", "allow"
-        )
-        policies.policy_api.set_rule(
-            "chat", "channel", 777, "chat.can_speak", "deny"
+            "chat", "user", 7, "chat.protected", "deny"
         )
 
-        policies.refresh_from_policy_api()
+        self.assertTrue(policies.is_protected(guild_id=1, channel_id=321, user_id=7))
 
-        rules = {
-            (rule.action, rule.effect)
-            for rule in policies.policy_api.get_scope_rules("chat", "channel", 777)
-        }
-        self.assertIn(("chat.feature.custom", "allow"), rules)
-        self.assertIn(("chat.can_speak", "deny"), rules)
-        channel_policy = policies.get_channel_policy(777)
+    def test_remove_protected_channel_clears_beacon_rule(self):
+        sonata = FakeSonata()
+        sonata.beacon.home = "Beacon/Home"
+        policies = ChannelPolicies(sonata)
+        policies.set_channel_flag(321, "protected", True)
+        policies.remove_channel_policy(321)
+
+        self.assertFalse(
+            policies.policy_api.evaluate(
+                "beacon",
+                "beacon.encrypt.path.beacon/home/chat/value/i321",
+                guild_id="__global__",
+                default=False,
+            )
+        )
+
+    def test_beacon_chat_history_action_collapses_repeated_slashes(self):
+        sonata = FakeSonata()
+        sonata.beacon.home = "//Beacon///Home//"
+        policies = ChannelPolicies(sonata)
+        action = policies._beacon_chat_history_action(99)
         self.assertEqual(
-            channel_policy.extra_rules,
-            [{"action": "chat.feature.custom", "effect": "allow"}],
+            action, "beacon.encrypt.path.beacon/home/chat/value/i99"
         )
 
 


### PR DESCRIPTION
## Summary
Add protected-channel chat policies across storage, logs, and terminal command access.

## What Changed
- added a persisted `protected` flag to channel chat policy state
- synced `chat.protected` into the policy engine and mapped protected channels to beacon path encryption rules
- suppressed guild chat log output for protected channels
- denied terminal commands that expose protected channel history (`sum`, `pchn`, and `cmd`)
- bridged the new unified policy admin flow so raw `chat` rules round-trip back into `ChannelPolicies` persistence and beacon protection state
- added coverage for protected policy persistence, beacon path encryption, and unified-policy compatibility

## Why
Protected channels need privacy guarantees at every layer, not just command gating. This change ensures new protected channels avoid plaintext beacon storage, stop leaking content into logs, and block terminal-side history access.

## Impact
Protected channels now enforce privacy consistently for newly saved chat history and local operator tooling. Existing encrypted or in-memory history behavior remains unchanged.

## Validation
- `PYTHONPATH=src uv run python -m unittest discover -s tests -p 'test_channel_policies.py'`
- `PYTHONPATH=src uv run python -m unittest discover -s tests -p 'test_policy_api.py'`
- `PYTHONPATH=src uv run python -m unittest discover -s tests -p 'test_beacon_policy.py'`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaqat/sonata/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chat protection policies with Beacon encryption for protected channels
> - Adds a `protected` boolean flag to `ChannelPolicy` that, when set on a channel, marks it as protected and registers a corresponding `beacon.encrypt.path.*` rule for that channel's chat history.
> - Introduces `ChannelPolicies.is_protected` to evaluate channel-scoped `chat.protected` rules, and `chat.is_protected` proxy on the chat plugin for use by other plugins.
> - Suppresses console logging of chat messages in protected channels and blocks `summarize_chat`, `print_channel_history`, and `run_self_cmd` term commands from accessing protected channel history.
> - Cleans up stale Beacon encryption rules when a channel policy is removed or refreshed, and prevents `chat.protected` from being set on non-channel scopes via the admin API.
> - Behavioral Change: `protected=True` on guild or user policies is silently forced to `False` during normalization; only channel-scoped policies honor the flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74b3611.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->