### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,21 @@ When implementation is complete:
 [Ready]    -> (agent picks up & implements)     -> [In Progress]
 [In Progress] -> (agent opens PR)               -> [In Review]
 ```
+
+## Cursor Cloud specific instructions
+
+Sonata is a single Python 3.12 process: an AI-powered Discord bot (`py-cord`). Dependencies are managed with `uv` (see `pyproject.toml`/`uv.lock`); the startup update script runs `uv sync`. There is no database or other service — persistence is local pickle files under `beacon-mainland/` (gitignored). `ffmpeg` (for voice) is preinstalled.
+
+Run/test/lint (standard commands live in `ReadME.md`; `ReadME.md` is stale on install — use `uv`, not `pip install -r requirements.txt`, which does not exist):
+
+- Run bot: `uv run python src/index.py` (from repo root; `src` is auto-added to `sys.path` because the entry uses `from __init__` / `from modules`).
+- Tests: `PYTHONPATH=src uv run python -m unittest discover -s tests -v`.
+- Type check: `uvx pyright` (`typeCheckingMode` is `off`; only reports missing imports).
+
+Non-obvious gotchas:
+
+- Tests MUST be run with `PYTHONPATH=src`; otherwise `test_channel_policies` fails at import with `No module named 'modules'`.
+- 10 tests in `tests/test_policy_api.py` fail pre-existing (`'FakeSonata' object has no attribute 'has'`) — the test's fake omits a method `channel_policies.py` calls. This is unrelated to environment setup; 51/61 tests pass otherwise.
+- The bot needs `OPENAI_API_KEY` present in the environment (even a placeholder) just to import: `openai.chat.completions` is a lazy proxy resolved when the `@register_ai` decorators run at import time.
+- Do NOT leave empty-string values for provider keys in `.env` (e.g. `X_AI=`). An empty string counts as "set", so `settings.X_AI` returns `""` and `XAIClient("")` raises `ValueError` during registration. To disable a provider, omit the line entirely (unset -> `None` -> registration skipped); to enable it, give a real key.
+- Full Discord end-to-end requires a real `BOT_TOKEN` plus at least one AI provider key (default chat model is Claude, so `ANTHROPIC_AI`). Without a token the bot boots through full initialization and then can only fail at Discord login. The core chat pipeline can be exercised offline by registering a local AI provider via `MANAGER.register_ai(...)` and calling `Sonata.chat.request(...)`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for Sonata (Python 3.12 `py-cord` Discord bot managed with `uv`) and documents durable, non-obvious run/test gotchas in `AGENTS.md`.

- Update script (VM startup): `uv sync`.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering how to run/test/lint and the key gotchas discovered during setup.

## Verification

- `uv sync` installs all deps.
- `PYTHONPATH=src uv run python -m unittest discover -s tests -v` -> 51/61 pass. The 10 failures are pre-existing (`'FakeSonata' object has no attribute 'has'` in `tests/test_policy_api.py`), unrelated to environment setup.
- `uvx pyright` -> clean aside from 2 pre-existing test-import warnings (`typeCheckingMode` is off).
- `uv run python src/index.py` boots through full initialization (patches, config, plugins, AI registration) to the Discord login boundary (no token in this env).
- Offline core-pipeline smoke test: registered a local AI provider via `MANAGER.register_ai(...)` and ran `Sonata.chat.request(...)` — a user message flowed through the prompt manager, AI dispatch, and was persisted to beacon chat history.

Notable gotchas documented in `AGENTS.md`:
- Tests require `PYTHONPATH=src`.
- The bot requires `OPENAI_API_KEY` present at import time (lazy `openai.chat.completions` proxy resolved by `@register_ai`).
- Empty-string provider keys in `.env` (e.g. `X_AI=`) break registration (`XAIClient("")` raises); omit the line to disable a provider instead.
- Full Discord E2E needs a real `BOT_TOKEN` + an AI provider key (default is Claude -> `ANTHROPIC_AI`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aea010a7-036a-417b-96e9-e707fbd603a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aea010a7-036a-417b-96e9-e707fbd603a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

