### PR TITLE
Fix bot whitelist ID check in process_commands

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 import discord.ext.commands.bot
 from discord.message import Message
@@ -8,7 +8,9 @@ from modules.utils import async_cprint as cprint
 
 
 async def process_commands(
-    self, message: Message, bot_whitelist: Optional[list[str]] = None
+    self,
+    message: Message,
+    bot_whitelist: Optional[list[Union[str, int]]] = None,
 ) -> None:
     """
     This is a patch for the process_commands function in discord.ext.commands.bot
@@ -16,7 +18,13 @@ async def process_commands(
     If the message author is a bot and not in the whitelist, it will not process the commands
     Otherwise, it will process the commands as normal
     """
-    if message.author.bot and (not bot_whitelist or message.author.name not in bot_whitelist):
+    if message.author.bot and (
+        not bot_whitelist
+        or (
+            message.author.name not in bot_whitelist
+            and message.author.id not in bot_whitelist
+        )
+    ):
         return
 
     ctx = await self.get_context(message)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`chat_hook` allows whitelisted bots through when listed by **username or Discord ID**, but the `process_commands` patch only checked `message.author.name`. Bots added by ID (including `1527366826793894109`) passed chat filtering and had messages rewritten to `$c …`, then silently dropped at command invocation — so Sonata never responded to their mentions or replies.

## Fix

Update `process_commands` in `src/__init__.py` to reject bot messages only when **neither** the author's name **nor** ID appears in `bot_whitelist`, matching `chat_hook`'s `VALID_USER` logic.

## Verification

After merge + deploy, a whitelisted bot replying to Sonata or saying "sonata" should trigger the usual `$c` AI response path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7012-6cc2-7210-9766-00010002e79b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7012-6cc2-7210-9766-00010002e79b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

