### PR TITLE
Add /delegate skill for orchestrator-only subagent workflows

### DIFF
--- a/.agents/skills/delegate/SKILL.md
+++ b/.agents/skills/delegate/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: delegate
+description: >-
+  Orchestrate implementation by creating subagents only. Use when the parent
+  model should plan, review, and delegate all code exploration and edits —
+  never run tools or edit files itself. Invoke via /delegate.
+disable-model-invocation: true
+---
+
+# Delegate
+
+You are an **orchestrator**. You do not implement. You only think, decompose work,
+launch subagents, review their results, and launch follow-up subagents until the
+user's task is done.
+
+## Hard constraints
+
+You may use **only** the `Task` tool (to create/resume subagents).
+
+You must **not**:
+
+- Edit, create, or delete files (`Write`, `StrReplace`, `Delete`, `EditNotebook`, etc.)
+- Run shell/git/PR commands (`Shell`, `ManagePullRequest`, etc.)
+- Read or search the codebase yourself (`Read`, `Grep`, `Glob`, `SemanticSearch`, etc.)
+- Call MCP tools or fetch URLs yourself
+- Use any other tool besides `Task`
+
+If you catch yourself about to touch the repo or run a tool other than `Task`,
+stop and spawn a subagent instead.
+
+## Model routing
+
+When launching a subagent, set `model` explicitly:
+
+| Situation | Model (user-facing) | `model` slug |
+|---|---|---|
+| Needs judgment, design, debugging, ambiguous requirements, multi-file architecture, or careful review | Cursor Grok 4.5 High Fast | `cursor-grok-4.5-high-fast` |
+| Well-defined, simple, mechanical, or tightly scoped steps with clear acceptance criteria | Composer 2.5 Fast | `composer-2.5-fast` |
+
+Default: if unsure whether thinking is needed, use **Cursor Grok 4.5 High Fast**.
+
+Do not invent other model slugs. Do not omit `model` and hope the child inherits yours.
+
+## Subagent type guidance
+
+- `explore` — map the codebase, find files/symbols, answer "where/how does X work?"
+- `generalPurpose` — implement changes, run tests, commit/push/PR when the task requires it
+- `best-of-n-runner` — isolated branch/worktree experiments when you need parallel attempts
+
+Prefer parallel `Task` calls when workstreams are independent.
+
+## Workflow
+
+1. **Restate the goal** briefly (in your thinking / to the user): success criteria, constraints, out of scope.
+2. **Decompose** into subagent-sized jobs. Each job should have a clear deliverable.
+3. **Brief each subagent completely.** Children do not see your prior context. Every `Task` prompt must include:
+   - The user goal and acceptance criteria
+   - Exactly what to do / what to return
+   - Relevant paths, ticket IDs, branch rules, and repo conventions you already know from the conversation
+   - What *not* to change
+   - Required output format (summary, files touched, test results, blockers)
+4. **Pick model + subagent_type** using the tables above.
+5. **Launch** one or more subagents via `Task`.
+6. **Review** their results critically:
+   - Did they meet the acceptance criteria?
+   - Any gaps, regressions, or scope creep?
+   - What is the next smallest set of jobs?
+7. **Iterate**: spawn follow-up subagents (use `resume` when continuing the same worker) until the task is complete or truly blocked.
+8. **Finish** with a concise user-facing summary of what the subagents did, what remains, and any decisions you made as orchestrator.
+
+## Prompting patterns
+
+### Exploration (usually Grok)
+
+```
+subagent_type: explore
+model: cursor-grok-4.5-high-fast
+```
+
+Ask for file paths, key symbols, and a short recommendation — not a full rewrite.
+
+### Simple implementation (Composer)
+
+```
+subagent_type: generalPurpose
+model: composer-2.5-fast
+```
+
+Give exact files/behavior/tests. Ask them to implement, verify, and report.
+
+### Hard implementation / debugging (Grok)
+
+```
+subagent_type: generalPurpose
+model: cursor-grok-4.5-high-fast
+```
+
+Include failure symptoms, constraints, and what "done" looks like.
+
+## Review checklist (orchestrator)
+
+Before declaring done, confirm via subagent reports that:
+
+- [ ] Acceptance criteria are satisfied
+- [ ] Changes stayed in scope
+- [ ] Tests/lints were run when appropriate
+- [ ] Branch/commit/PR steps were handled by a subagent when required by the environment
+- [ ] No follow-up jobs remain that you could still delegate
+
+## Communication
+
+- Speak to the user in their model names ("Composer 2.5 Fast", "Cursor Grok 4.5 High Fast"), not kebab-case slugs.
+- Do not dump raw subagent transcripts; synthesize.
+- If blocked (missing credentials, unclear requirements, policy limits), say what is blocked and which subagent hit it — do not work around by using tools yourself.

--- a/.agents/workflows/delegate.md
+++ b/.agents/workflows/delegate.md
@@ -1,0 +1,24 @@
+---
+description: Orchestrate work via subagents only — parent thinks/reviews, never edits.
+---
+
+# /delegate
+
+Parent model is orchestrator-only: plan, review, and create subagents until done.
+Do not run tools or edit files yourself — only use `Task`.
+
+## Model routing
+
+- Needs thinking / judgment / debugging → **Cursor Grok 4.5 High Fast** (`cursor-grok-4.5-high-fast`)
+- Well-defined or simple work → **Composer 2.5 Fast** (`composer-2.5-fast`)
+- If unsure → Grok
+
+## Loop
+
+1. Decompose the user task into clear subagent jobs
+2. Launch `Task` subagents with full context (children inherit none)
+3. Review outputs against acceptance criteria
+4. Spawn follow-ups / `resume` until complete
+5. Summarize results for the user
+
+Full instructions: `.agents/skills/delegate/SKILL.md`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `/delegate` skill (and matching workflow) for running a large parent model as a pure orchestrator.

### What
- New skill at `.agents/skills/delegate/SKILL.md`
- Slash-only via `disable-model-invocation: true` so it does not auto-trigger
- Parent may only use the `Task` tool — no codebase edits, shell, search, or MCP
- Model routing for subagents:
  - Thinking / judgment / debugging → **Cursor Grok 4.5 High Fast**
  - Well-defined / simple work → **Composer 2.5 Fast**
- Includes decompose → brief → launch → review → iterate loop and prompting patterns

### Why
Lets an expensive parent model stay in plan/review mode while cheaper/faster workers do exploration and implementation.

cc @blaqat
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f70e5-ff3a-77e3-820f-5115f1c02300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f70e5-ff3a-77e3-820f-5115f1c02300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

