### PR TITLE
Tighten /delegate skill: no nested Task, two-model allowlist

### DIFF
--- a/.agents/skills/delegate/SKILL.md
+++ b/.agents/skills/delegate/SKILL.md
@@ -15,7 +15,7 @@ user's task is done.
 
 ## Hard constraints
 
-You may use **only** the `Task` tool (to create/resume subagents).
+You may use **only** the `Task` tool (to create/resume subagents). **Only the orchestrator may delegate.** Delegated workers must **not** launch their own subagents or `Task` calls — this prevents hidden model selection and extra API usage. If a worker needs more help, it must return a blocker or recommendation to you; you decide whether to spawn a follow-up worker.
 
 You must **not**:
 
@@ -30,7 +30,7 @@ stop and spawn a subagent instead.
 
 ## Model routing
 
-When launching a subagent, set `model` explicitly:
+Every delegated task at **every nesting level** may use **only** these two model slugs:
 
 | Situation | Model (user-facing) | `model` slug |
 |---|---|---|
@@ -39,7 +39,14 @@ When launching a subagent, set `model` explicitly:
 
 Default: if unsure whether thinking is needed, use **Cursor Grok 4.5 High Fast**.
 
-Do not invent other model slugs. Do not omit `model` and hope the child inherits yours.
+When launching a subagent, set `model` explicitly to one of the two slugs above. **Prohibited for delegated work:** Claude Sonnet, Claude Opus, Claude Fable, GPT, Gemini, or any other model slug. Do not omit `model` and hope the child inherits yours.
+
+## Preflight checklist (before every `Task` call)
+
+Verify before each launch:
+
+- [ ] `model` is explicitly set to `composer-2.5-fast` or `cursor-grok-4.5-high-fast` — never omitted, never another slug
+- [ ] Worker prompt includes: **do not launch subagents or `Task` calls**; return blockers or recommendations to the orchestrator instead
 
 ## Subagent type guidance
 
@@ -58,6 +65,7 @@ Prefer parallel `Task` calls when workstreams are independent.
    - Exactly what to do / what to return
    - Relevant paths, ticket IDs, branch rules, and repo conventions you already know from the conversation
    - What *not* to change
+   - **No nested delegation:** do not launch subagents or `Task` calls; return blockers or recommendations to the orchestrator if more help is needed
    - Required output format (summary, files touched, test results, blockers)
 4. **Pick model + subagent_type** using the tables above.
 5. **Launch** one or more subagents via `Task`.


### PR DESCRIPTION
## Summary
- Workers must not nest-delegate via `Task` (orchestrator-only)
- Delegated work may use only `composer-2.5-fast` or `cursor-grok-4.5-high-fast`
- Add a short preflight checklist before every `Task` launch

## Test plan
- [ ] Read `.agents/skills/delegate/SKILL.md` and confirm constraints are clear
- [ ] Run `/delegate` once and verify Task prompts include no-nested-delegation language


Made with [Cursor](https://cursor.com)