### PR TITLE
SONA-127: Remove predefined chat responses and trailing flags

### DIFF
--- a/sonata.config.json
+++ b/sonata.config.json
@@ -24,24 +24,6 @@
       "auto": "c",
       "view_replies": true,
       "ignore": [],
-      "response_map": {
-        "subi": [
-          0.005,
-          "i dont know but can you play piano for me? <a:kittypleading:1213940324658057236>"
-        ],
-        "log": [
-          0.005,
-          "BWAAAAAAAA BWAAAAAA BWAAAAAAAAAAAAA"
-        ],
-        "blaqat": [
-          0.005,
-          "yes master"
-        ],
-        "ans": [
-          0.01,
-          "youre the robot why dont u tell me hmmm?"
-        ]
-      },
       "bot_whitelist": [
         "BluBot",
         1311742291521835048,

--- a/src/index.py
+++ b/src/index.py
@@ -1252,11 +1252,6 @@ async def ai_question(ctx, *message, ai, short, error_prompt=None):
     channel = await get_channel(ctx)
     try:
         message = " ".join(message)
-        if message is None or message == "":
-            message = "0"
-        respond_or_chat = message[-1] == "1"
-        message = message[:-1]
-        # respond_or_chat = False
 
         name = get_full_name(ctx)
         _ref = None
@@ -1278,9 +1273,7 @@ async def ai_question(ctx, *message, ai, short, error_prompt=None):
             )
             if intercept_reply is not None:
                 r = await intercept_reply(r, Sonata)
-                await ctx_reply(ctx, r, not respond_or_chat)
-            else:
-                await ctx_reply(ctx, r, not respond_or_chat)
+            await ctx_reply(ctx, r)
             Sonata.chat.send(channel.id, "Bot", Sonata.name, r, _ref)
         RESPONSE_FAILURES[(await get_channel(ctx)).id] = 0
     except Exception as e:

--- a/src/modules/plugins/chat.py
+++ b/src/modules/plugins/chat.py
@@ -52,7 +52,6 @@ from modules.utils import (
     gif_provider_get_dl_url,
     get_trace,
 )
-import random
 import re
 from zoneinfo import ZoneInfo
 
@@ -65,7 +64,6 @@ CONTEXT, MANAGER, PROMPT_MANAGER = AI_Manager.init(
         "auto": "o",
         "view_replies": True,
         "ignore": [],
-        "response_map": {},  # {userName: (response, random chance)}
         "bot_whitelist": [],
         "censor": True,
     },
@@ -223,7 +221,6 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
     CENSOR = Sonata.config.get("censor", True)
     USE_REPLY_REF = Sonata.config.get("view_replies")
     IGNORE_LIST = Sonata.config.get("ignore", [])
-    RESPONSES = Sonata.config.get("response_map", {})
     BOT_WHITELIST = Sonata.config.get("bot_whitelist", [])
     VALID_USER = (
         message.author.bot
@@ -431,20 +428,6 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
         #     message.reference.message_id
         # )
         if message_reference_id == self.user.id:
-            if (
-                message.author.name in RESPONSES
-                or message.author.nick
-                and message.author.nick in RESPONSES
-            ):
-                chance, response = RESPONSES.get(
-                    message.author.name, RESPONSES.get(message.author.nick)
-                )
-                if random.random() < chance:
-                    await message.reply(response, mention_author=False)
-                    Sonata.chat.send(message.channel.id, "Bot", "sonata", response)
-                    message.content += "1"
-            else:
-                message.content += "0"
             message.content = f"${AI} " + message.content
             await self.process_commands(message, bot_whitelist=BOT_WHITELIST)
             return
@@ -455,16 +438,6 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
     if VALID_USER and (sonata_exp.search(message.content) or respond_all):
         message.content = sonata_exp.sub("", message.content).strip()
         message.content = f"${AI} {message.content}"
-        if _name in RESPONSES:
-            chance, response = RESPONSES.get(
-                message.author.name, RESPONSES.get(message.author.nick)
-            )
-            if random.random() < chance:
-                await message.reply(response, mention_author=False)
-                Sonata.chat.send(message.channel.id, "Bot", "sonata", response)
-                message.content += "1"
-        else:
-            message.content += "0"
 
     await self.process_commands(message, bot_whitelist=BOT_WHITELIST)
 

--- a/src/sonata_config.py
+++ b/src/sonata_config.py
@@ -107,15 +107,6 @@ def _project_plugin_defaults() -> dict[str, Any]:
             "view_replies": True,
             "auto": "c",
             "ignore": [],
-            "response_map": {
-                "subi": [
-                    0.005,
-                    "i dont know but can you play piano for me? <a:kittypleading:1213940324658057236>",
-                ],
-                "log": [0.005, "BWAAAAAAAA BWAAAAAA BWAAAAAAAAAAAAA"],
-                "blaqat": [0.005, "yes master"],
-                "ans": [0.01, "youre the robot why dont u tell me hmmm?"],
-            },
             "bot_whitelist": [
                 "BluBot",
                 1311742291521835048,

--- a/tests/test_chat_routing.py
+++ b/tests/test_chat_routing.py
@@ -1,0 +1,301 @@
+import ast
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+
+def _load_chat_module():
+    module_path = SRC_ROOT / "modules" / "plugins" / "chat.py"
+    spec = importlib.util.spec_from_file_location("chat_plugin_test", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load chat module spec")
+
+    class _Manager:
+        MANAGER = types.SimpleNamespace(config={})
+
+        @staticmethod
+        def _decorator(*args, **kwargs):
+            if len(args) == 1 and callable(args[0]) and not kwargs:
+                return args[0]
+            return lambda function: function
+
+        builder = _decorator
+        effect = _decorator
+        effect_post = _decorator
+        mem = _decorator
+        prompt = _decorator
+        with_context = _decorator
+
+    manager = _Manager()
+    context = types.SimpleNamespace(plugin_config={})
+    prompt_manager = types.SimpleNamespace()
+
+    class _AIManager:
+        @staticmethod
+        def init(*_args, **_kwargs):
+            return context, manager, prompt_manager
+
+    ai_manager_stub = types.ModuleType("modules.AI_manager")
+    ai_manager_stub.AI_Manager = _AIManager
+    ai_manager_stub.Context = object
+
+    channel_policies_stub = types.ModuleType("modules.channel_policies")
+    channel_policies_stub.LEGACY_CHANNEL_BLACKLIST = set()
+    channel_policies_stub.ChannelPolicies = object
+    channel_policies_stub.get_channel_policy = lambda *_args, **_kwargs: {}
+    channel_policies_stub.get_command_name = lambda content: (
+        content.split(maxsplit=1)[0].lstrip("$") if content.startswith("$") else None
+    )
+
+    async def _get_reference(message):
+        return message.resolved_reference
+
+    async def _get_reference_chain(message, **_kwargs):
+        return message
+
+    utils_stub = types.ModuleType("modules.utils")
+    utils_stub.censor_message = lambda message, _words: message
+    utils_stub.async_print = lambda *_args, **_kwargs: None
+    utils_stub.async_cprint = lambda *_args, **_kwargs: None
+    utils_stub.cstr = lambda **kwargs: kwargs["str"]
+    utils_stub.get_full_name = lambda message: message.author.name
+    utils_stub.setter = lambda *_args, **_kwargs: None
+    utils_stub.settings = types.SimpleNamespace(TENOR_G="", KLIPY="")
+    utils_stub.has_inside = lambda *_args, **_kwargs: False
+    utils_stub.get_reference_message = _get_reference
+    utils_stub.get_reference_chain = _get_reference_chain
+    utils_stub.gif_provider_get_dl_url = lambda url, *_args, **_kwargs: url
+    utils_stub.get_trace = lambda: ""
+
+    discord_stub = types.ModuleType("discord")
+    discord_stub.Message = object
+    discord_stub.utils = types.SimpleNamespace(utcnow=lambda: None)
+    discord_ext_stub = types.ModuleType("discord.ext")
+    commands_stub = types.ModuleType("discord.ext.commands")
+    commands_stub.Bot = object
+    discord_ext_stub.commands = commands_stub
+
+    stubs = {
+        "modules.AI_manager": ai_manager_stub,
+        "modules.channel_policies": channel_policies_stub,
+        "modules.utils": utils_stub,
+        "discord": discord_stub,
+        "discord.ext": discord_ext_stub,
+        "discord.ext.commands": commands_stub,
+    }
+    originals = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+class _Config:
+    def __init__(self, **values):
+        self.values = values
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class _PolicyManager:
+    def __init__(self, respond_all=False):
+        self.respond_all = respond_all
+
+    def can_speak(self, **_kwargs):
+        return True
+
+    def is_command_allowed(self, **_kwargs):
+        return True
+
+    def should_respond_all(self, **_kwargs):
+        return self.respond_all
+
+
+class _Chat:
+    def __init__(self, respond_all=False):
+        self.policy_manager = _PolicyManager(respond_all)
+        self.saved = []
+
+    def send(self, *args):
+        self.saved.append(args)
+
+
+class _Message:
+    def __init__(self, content, reference=None):
+        self.content = content
+        self.author = types.SimpleNamespace(
+            bot=False,
+            name="alice",
+            nick=None,
+            id=7,
+            roles=[],
+            color=None,
+        )
+        self.guild = types.SimpleNamespace(id=1, name="Guild")
+        self.channel = types.SimpleNamespace(id=2, name="general")
+        self.attachments = []
+        self.resolved_reference = reference
+        self.replies = []
+
+    async def reply(self, content, **kwargs):
+        self.replies.append((content, kwargs))
+
+
+class _Bot:
+    def __init__(self):
+        self.user = types.SimpleNamespace(id=99)
+        self.current_guild = ""
+        self.current_channel = ""
+        self.processed = []
+
+    async def process_commands(self, message, **kwargs):
+        self.processed.append((message.content, kwargs))
+
+
+class ChatHookRoutingTests(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chat_module = _load_chat_module()
+
+    async def _run_hook(self, content, *, reference=None, respond_all=False):
+        sonata = types.SimpleNamespace(
+            config=_Config(
+                auto="c",
+                censor=False,
+                view_replies=True,
+                ignore=[],
+                bot_whitelist=[],
+                response_map={"alice": [1, "obsolete response"]},
+            ),
+            chat=_Chat(respond_all),
+        )
+        bot = _Bot()
+        message = _Message(content, reference)
+        await self.chat_module.chat_hook(sonata, bot, message)
+        return sonata, bot, message
+
+    async def test_direct_mention_preserves_trailing_digit(self):
+        sonata, bot, message = await self._run_hook("Sonata keep this 1")
+
+        self.assertEqual(bot.processed[0][0], "$c keep this 1")
+        self.assertEqual(message.replies, [])
+        self.assertFalse(
+            any(entry[1] == "Bot" for entry in sonata.chat.saved),
+            "legacy predefined responses must not be emitted",
+        )
+
+    async def test_reply_to_sonata_preserves_trailing_digit(self):
+        reference = types.SimpleNamespace(author=types.SimpleNamespace(id=99))
+        _, bot, _ = await self._run_hook("keep this 0", reference=reference)
+
+        self.assertEqual(bot.processed[0][0], "$c keep this 0")
+
+    async def test_respond_all_preserves_trailing_digit(self):
+        _, bot, _ = await self._run_hook("keep this 1", respond_all=True)
+
+        self.assertEqual(bot.processed[0][0], "$c keep this 1")
+
+    async def test_explicit_command_is_not_rewritten(self):
+        _, bot, _ = await self._run_hook("$c keep this 0")
+
+        self.assertEqual(bot.processed[0][0], "$c keep this 0")
+
+
+def _load_ai_question():
+    source = (SRC_ROOT / "index.py").read_text()
+    tree = ast.parse(source)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "ai_question"
+    )
+    namespace = {"RESPONSE_FAILURES": {}, "MAX_FAILURES": 3}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), "src/index.py", "exec"), namespace)
+    return namespace["ai_question"], namespace
+
+
+class _Typing:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class AIQuestionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_ai_question_preserves_final_zero_and_one_and_replies(self):
+        ai_question, namespace = _load_ai_question()
+        requests = []
+        replies = []
+        channel = types.SimpleNamespace(id=12)
+
+        class _RuntimeConfig:
+            def set(self, **_kwargs):
+                pass
+
+            def get(self, _key, default=None):
+                return default
+
+        class _RuntimeChat:
+            def request(self, _channel_id, message, *_args, **_kwargs):
+                requests.append(message)
+                return "answer"
+
+            def send(self, *_args):
+                pass
+
+        sonata = types.SimpleNamespace(
+            config=_RuntimeConfig(),
+            chat=_RuntimeChat(),
+            name="Sonata",
+            get=lambda *_args, **_kwargs: None,
+        )
+        ctx = types.SimpleNamespace(typing=lambda: _Typing(), message=object())
+
+        async def get_channel(_ctx):
+            return channel
+
+        async def ctx_reply(*args):
+            replies.append(args)
+
+        namespace.update(
+            {
+                "Sonata": sonata,
+                "asyncio": asyncio,
+                "get_channel": get_channel,
+                "get_full_name": lambda _ctx: "alice",
+                "get_chain": lambda _message: None,
+                "ctx_reply": ctx_reply,
+                "cprint": lambda *_args, **_kwargs: None,
+                "print": lambda *_args, **_kwargs: None,
+                "get_trace": lambda: "",
+                "ordinal": lambda value: str(value),
+                "settings": types.SimpleNamespace(GOD=1),
+                "restart": lambda: None,
+            }
+        )
+
+        for content in ("natural 0", "natural 1"):
+            await ai_question(ctx, content, ai="Claude", short="c")
+
+        self.assertEqual(requests, ["natural 0", "natural 1"])
+        self.assertEqual(replies, [(ctx, "answer"), (ctx, "answer")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements [SONA-127](https://app.notion.com/p/3ad243549f6381d38105e4c897a7ce43): remove guild-chat `response_map` predefined replies and the hidden trailing `0`/`1` content sentinel used to choose Discord reply vs send.

- Stop reading/sending predefined responses from `response_map` in `chat_hook`
- Stop appending `0`/`1` to message content before AI command processing
- Stop stripping/interpreting the final character in `ai_question`; reply with normal `ctx_reply` behavior
- Remove obsolete `response_map` config from `sonata.config.json` and defaults
- Add `tests/test_chat_routing.py` covering mentions, replies, `respond_all`, commands, and messages ending in `0`/`1`

## Test plan

- [x] `python3 -m unittest tests.test_chat_routing -v`
- [ ] Confirm direct mentions / reply-to-Sonata / commands / `respond_all` still invoke AI
- [ ] Confirm user text ending in `0` or `1` reaches the model unchanged

cc @blaqat