### PR TITLE
SONA-129: Prioritize leading $commands over AI rewrite

### DIFF
--- a/src/modules/plugins/chat.py
+++ b/src/modules/plugins/chat.py
@@ -424,21 +424,24 @@ async def chat_hook(Sonata, self: commands.Bot, message: discord.Message) -> Non
     ):
         return
 
-    # Pass referenced messages to AI
+    # Pass referenced messages to AI (leading $command takes priority)
     if message_reference_id is not None and VALID_USER:
         # Check if reference is pointing to a message sent by the bot
         # message_reference = await message.channel.fetch_message(
         #     message.reference.message_id
         # )
         if message_reference_id == self.user.id:
-            message.content = f"${AI} " + message.content
+            if not is_command:
+                message.content = f"${AI} " + message.content
             await self.process_commands(message, bot_whitelist=BOT_WHITELIST)
             return
         #
         # await self.process_commands(message)
         # return
 
-    if VALID_USER and (sonata_exp.search(message.content) or respond_all):
+    if VALID_USER and not is_command and (
+        sonata_exp.search(message.content) or respond_all
+    ):
         message.content = sonata_exp.sub("", message.content).strip()
         message.content = f"${AI} {message.content}"
 

--- a/tests/test_chat_routing.py
+++ b/tests/test_chat_routing.py
@@ -215,6 +215,43 @@ class ChatHookRoutingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(bot.processed[0][0], "$c keep this 0")
 
+    async def test_leading_command_with_wake_keyword_stays_command(self):
+        _, bot, _ = await self._run_hook("$help sonata")
+
+        self.assertEqual(bot.processed[0][0], "$help sonata")
+
+    async def test_leading_command_with_sona_keyword_stays_command(self):
+        _, bot, _ = await self._run_hook("$play foo sona")
+
+        self.assertEqual(bot.processed[0][0], "$play foo sona")
+
+    async def test_reply_to_sonata_with_leading_command_stays_command(self):
+        reference = types.SimpleNamespace(author=types.SimpleNamespace(id=99))
+        _, bot, _ = await self._run_hook("$help", reference=reference)
+
+        self.assertEqual(bot.processed[0][0], "$help")
+
+    async def test_reply_to_sonata_plain_text_still_ai(self):
+        reference = types.SimpleNamespace(author=types.SimpleNamespace(id=99))
+        _, bot, _ = await self._run_hook("hello there", reference=reference)
+
+        self.assertEqual(bot.processed[0][0], "$c hello there")
+
+    async def test_keyword_first_with_embedded_command_stays_ai(self):
+        _, bot, _ = await self._run_hook("sonata $help")
+
+        self.assertEqual(bot.processed[0][0], "$c $help")
+
+    async def test_keyword_first_play_stays_ai(self):
+        _, bot, _ = await self._run_hook("sona $play something")
+
+        self.assertEqual(bot.processed[0][0], "$c $play something")
+
+    async def test_keyword_only_still_ai(self):
+        _, bot, _ = await self._run_hook("hey sonata what is up")
+
+        self.assertEqual(bot.processed[0][0], "$c hey  what is up")
+
 
 def _load_ai_question():
     source = (SRC_ROOT / "index.py").read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SONA-129](https://app.notion.com/p/3b0243549f63818cb78cfbdd2f6fe63c): when a guild message **starts with** a `$command`, Sonata now runs that command instead of rewriting the message into `$AI …` — including when a wake keyword is present or the message is a reply to Sonata.

Keyword-first messages (e.g. `sonata $help`) are unchanged and stay on the wake-keyword / AI path.

## Changes

- `src/modules/plugins/chat.py` (`chat_hook` guild path):
  - Reply-to-Sonata: only prepend `$AI` when the message is **not** already a leading command
  - Wake keyword / `respond_all`: skip `$AI` rewrite when `is_command` is already true
- `tests/test_chat_routing.py`: regression coverage for command-first + keyword, reply + command, keyword-first with embedded `$…`, and baselines

## Validation

- `python3 -m unittest tests.test_chat_routing -v` — 12 passed

cc @blaqat
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aedc2954-052c-4ddd-aa0c-f06e5007bdb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aedc2954-052c-4ddd-aa0c-f06e5007bdb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prioritize explicit `$commands` over AI rewrite in `chat_hook`
> - Messages starting with an explicit `$command` are no longer rewritten to `$<AI>`, even when a wake keyword is present, `respond_all` is enabled, or the message is a reply to the bot.
> - Previously, replying to the bot or triggering a wake keyword would unconditionally prepend the AI command prefix, overriding any leading `$command` in the message.
> - Adds tests in [test_chat_routing.py](https://github.com/blaqat/sonata/pull/44/files#diff-ef46a96cc74891a30812cb76f84e6e824c03019a61c6e3d520725cab79350620) covering all affected routing paths, including edge cases where a wake keyword appears before a `$command` token (still routes to AI).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8e862a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->